### PR TITLE
Explicitly use Python 3

### DIFF
--- a/kdk
+++ b/kdk
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import getpass


### PR DESCRIPTION
A lot of operating systems still default to Python 2.

i.e.
MacOS:
> $ python --version
> Python 2.7.15

Debian 9/Stretch
> $ python --version
> Python 2.7.13