### PR TITLE
Update PyYAML to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click==6.7
 docker==3.3.0
 executor==20.0
-PyYAML==3.12
+PyYAML==3.13


### PR DESCRIPTION
With the current version of PyYAML set on ```requirements.txt``` (3.12) it will [break](https://github.com/yaml/pyyaml/issues/126) if you have Python 3.7

Has been [fixed](https://github.com/yaml/pyyaml/issues/126#issuecomment-403075935) in PyYAML 3.13