### PR TITLE
Feature/windows support

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,4 +1,4 @@
-FROM debian:9.5-slim
+FROM debian:9.5
 
 LABEL maintainer="rluckie@cisco.com"
 
@@ -57,8 +57,6 @@ RUN echo "Install OS packages" && \
         socat \
         software-properties-common \
         sudo \
-        systemd \
-        systemd-sysv \
         tcl \
         telnet \
         traceroute \

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 Kubernetes Development Kit (KDK)
 ===
 
-This Dockerized KDK has only been tested with OSX.  If you need Windows10
-support, try [k8s-devkit](https://github.com/cisco-sso/k8s-devkit).
+## Quickstart (`TL;DR`)
+
+```console
+curl -sSL https://raw.githubusercontent.com/cisco-sso/kdk/master/install | sudo bash && kdk pull && kdk init && kdk up && kdk ssh
+```
 
 ## Background
 
@@ -28,53 +31,90 @@ colordiff, nmap, screen, tmux, yadm, and many others.
   * Developing and applying Helm Charts and mh Apps.
   * Developing docker containers.
 
-## Dependencies Setup
+## Setup
 
-### OSX Specfic Setup Instructions
+### OSX
 
-```bash
+1. Install [homebrew](https://brew.sh/)
+```console
 # Open a Terminal
 <Spotlight_Search -> Terminal>
-
-# Install Homebrew (https://brew.sh/)
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+```
+2. Install required utils
 
-# Install Git, Keybase
-#   If you are a Keybase user, the KeybaseFS may be mounted directly into the docker image.
+```console
 brew install git
 brew cask install keybase
-
-# Install Docker for Mac
-open https://docs.docker.com/docker-for-mac/install/
 ```
 
-### Windows Specific Setup Instructions
+3. Install Docker from [here](https://docs.docker.com/docker-for-mac/release-notes/)
 
-```bash
-# Open a Windows Powershell
-<Windows_Search -> Powershell (Right click, Start as Administrator)>
+### Windows
 
-# Install Chocolatey (https://chocolatey.org)
+1. Install [chocolatey](https://chocolatey.org)
+
+```console
+# Open Powershell as Administrator
 Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-
-# Install Git, Keybase, and other utils
-#   If you are a Keybase user, the KeybaseFS may be mounted directly into the docker image.
-choco.exe install -y keybase openssh git curl
 ```
 
-* Download and install docker from [here](https://docs.docker.com/docker-for-windows/release-notes/)
+2. Install required utils
 
-## Dependencies Configuration
+```console
+# Open Powershell as Administrator
+choco install -y openssh git curl
+```
 
-## Configure Keybase
+3. Install Docker from [here](https://docs.docker.com/docker-for-windows/release-notes/)
 
-```bash
+4. Install Keybase from [here](https://keybase.io/docs/the_app/install_windows)
+
+
+## Dependency Configuration
+
+### SSH
+
+1. Open a terminal
+
+```console
+OSX: <Spotlight_Search -> Terminal>
+Windows: <Windows_Search -> "Git Bash">
+```
+2. Start `ssh-agent`
+
+```console
+eval `ssh-agent`
+```
+
+3. Generate ssh key
+
+```console
+if [[ ! -f ~/.ssh/id_rsa ]]; then ssh-keygen -b 4096 -t rsa -f ~/.ssh/id_rsa -q -N ""; fi
+```
+
+4. Add generated ssh key to ssh-agent
+
+```console
+ssh-add ~/.ssh/id_rsa
+```
+
+5. Add ssh public key to github
+
+* Add content of `~/.ssh/id_rsa.pub` to [here](https://github.com/settings/keys)
+
+6. Add ssh public key to gitbucket
+
+* Add content of `~/.ssh/id_rsa.pub` to https://<BITBUCKET-SERVER>/bitbucket/plugins/servlet/ssh/account/keys
+
+### Keybase
+
+```console
 # Start Keybase
 OSX: <Spotlight_Search -> Keybase>
 Windows: <Windows_Search -> Keybase>
 
-# Ensure you are registered on keybase with your full name and at least one
-#   verification.  Keybase is the encrypted store used to share team secrets.
+# Ensure you are registered on keybase with your full name and at least one verification.  
 # Ask your team lead to add you to any relevant keybase teams.
 
 # Ensure that keybaseFS is configured and mounted on your system
@@ -85,70 +125,49 @@ OSX: ls /keybase
 Windows: dir k:
 ```
 
-## Configure SSH
+## Download and Initialize the KDK
 
-```bash
+1. Open a terminal
 
-# Open a bash shell and go to your home directory
+```console
 OSX: <Spotlight_Search -> Terminal>
 Windows: <Windows_Search -> "Git Bash">
-cd ~/
-
-# Ensure you have an ssh-key generated with default settings
-#   Paste the following into bash
-if [ ! -e ~/.ssh/id_rsa ]; then ssh-keygen -b 4096; done
-
-# Provision the ssh key in your github.com account
-#   Your new public key is here: ~/.ssh/id_rsa.pub
-#   https://github.com/settings/keys
-
-# Provision the ssh key in your bitbucket account
-#   Your new public key is here: ~/.ssh/id_rsa.pub
-#   https://<BITBUCKET-SERVER>/bitbucket/plugins/servlet/ssh/account/keys
 ```
 
-## Download and Configure the Dockerized KDK
+2. Install the KDK
 
-```bash
+```console
+curl -sSL https://raw.githubusercontent.com/cisco-sso/kdk/master/install | sudo bash
+```
 
-# Open a bash shell and go to your home directory
-OSX: <Spotlight_Search -> Terminal>
-Windows: <Windows_Search -> "Git Bash">
-cd ~/
+3. create KDK config [`~/.kdk/config.yaml`] and ssh keys 
 
-# If you want to save your files in between VM creation and destroy, create a
-# ~/Dev directory which will be auto-mounted into the virtualmachine from the
-# host.  This currently is NOT RECOMMENDED FOR WINDOWS, because git cloned
-# symlinks and file line-endings do not work well on a windows host-mounted fs.
-# Using a host mounted ~/Dev directory is favorable so that you are able to
-# edit source code on the host machine using your host editor.
-OSX: mkdir ~/Dev; cd ~/Dev
-Windows: <Ignore This>
-
-
-
-# Download the binary for your kdk (OSX)
-curl -sSL https://github.com/cisco-sso/kdk/releases/download/0.5.3/kdk-0.5.3-darwin-amd64.tar.gz \
-  | tar xz && chmod +x darwin-amd64/kdk && sudo mv darwin-amd64/kdk /usr/local/bin/kdk && rm -rf darwin-amd64
-
-# Create your ~/.kdk/config.yaml
+```console
 kdk init
+```
 
-# Start ssh-agent and load your key
-eval `ssh-agent`
+4. Add KDK ssh key to ssh-agent
+
+```console
 ssh-add ~/.kdk/ssh/id_rsa
-ssh-add -l  # verify that the key has been loaded
+```
 
+5. Edit KDK config [`~/.kdk/config.yaml`] to suit your needs.
 
-# Edit your ~/.kdk/config.yaml with additional volume mounts if you would like
-#   to mount host directories into the docker machine.  Additional volume bind
-#   mount examples include:
+```yaml
+# Edit the KDK config to add additional volume mounts if you would like to mount host directories into the KDK container.
+
+# Additional volume binds may include:
+...
+docker:
+...
   binds:
+    ...
     - source: /Users/<YOUR_USERID>/<YOUR_PROJECT_DIR>
       target: /home/<YOUR_USERID>/<YOUR_PROJECT_DIR>
     - source:  "/Volumes/Keybase (<YOUR_KEYBASE_ID)/"
       target: /keybase
-
+...
 ```
 
 ## Use the KDK
@@ -170,19 +189,19 @@ kdk destroy
 
 ## Customization
 
-* **NOTE:**  The `kdk up` binary uses a set of opinionated dotfiles by default
-* Fork [this](https://github.com/cisco-sso/yadm-dotfiles) repo, make changes,
-  and update `launch-kdk` script accordingly to point to your customized fork.
+* **NOTE:**  By default, the `KDK` uses a set of opinionated dotfiles. 
+To customize, fork [this](https://github.com/cisco-sso/yadm-dotfiles) repo, make changes, and update `~/.kdk/config.yaml` to reference customized fork.
 
 
-## Configuring your KDK Machine
+## Common Configurations
+### AWS
 
 * `~/.aws/config`: Ensure there is an entry for each AWS account that you must
   access.  Tools such as the aws-cli, kops, and helm depend on these settings.
   The name of each profile must match that listed in the http://go2/aws (Cisco
   only) index page.
 
-```bash
+```console
 # EXAMPLE: ~/.aws/config
 
 [profile account-foo]
@@ -200,7 +219,7 @@ region = us-west-1
   http://go2/aws index page.  Be sure to replace your key_id and access_key for
   each entry.
 
-```bash
+```console
 # EXAMPLE: ~/.aws/credentials
 [account-foo]
 aws_access_key_id = XXXXXXXXXXXXXXXXXXXX
@@ -211,59 +230,38 @@ aws_access_key_id = XXXXXXXXXXXXXXXXXXXX
 aws_secret_access_key = YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
 ```
 
-## Using your KDK Machine
-
-```
-cd ~/
-git clone git@github.com:cisco-sso/k8s-deploy.git  # Or platform-deploy within Cisco
-cd k8s-deploy
-direnv allow
-
-# All of your work must be done from a cluster directory.  Upon entering a
-#   cluster directory, `direnv` will automatically set your enviromental
-#   configurations.  Upon entering a cluster directory for the first time, you
-#   must run `direnv allow` to permanently record that direnv is allowed to
-#   execute the .envrc script.
-
-# Activate cluster1 settings by entering the directory
-cd clusters/cluster1.domain.com
-direnv allow
-
-# Ensure that aws cli works
-#   Upon failure, check your ~/.aws config files
-aws ec2 describe-instances
-
-# Check that kops works
-kops validate cluster
-
-# Check that kubectl works
-kubectl cluster-info
-
-# Check that helm works
-helm ls
-
-# Activate cluster3 settings by entering the directory
-cd ../cluster3.domain.com
-direnv allow
-... <do the same thing above to verify that you can access cluster3>
-```
-
 ## Updating your KDK Machine
 
-```bash
-# Re-install by downloading the latest binary (OSX)
-curl -sSL https://github.com/cisco-sso/kdk/releases/download/0.5.3/kdk-0.5.3-darwin-amd64.tar.gz \
-  | tar xz && chmod +x darwin-amd64/kdk && sudo mv darwin-amd64/kdk /usr/local/bin/kdk && rm -rf darwin-amd64
+1. Update KDK bin
+```console
+curl -sSL https://raw.githubusercontent.com/cisco-sso/kdk/master/install | sudo bash
+```
+2. Download latest KDK image
 
-# Download the latest image
+```console
 kdk pull
+```
+3. Destroy previous KDK container
+
+```console
 kdk destroy
+```
+
+4. Recreate KDK config (may be optional).
+
+```console
+kdk init
+```
+
+5. Customize `~/.kdk/config.yaml` to suit your needs (if config was regenerated).
+
+6. Start KDK container
+
+```console
 kdk up
 ```
 
 ## Saving and Restoring snapshots
-
-It is often useful to save a snapshot of the vagrant machine.
 
 TODO: Finish this section
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Dockerized Kubernetes Development Kit (KDK)
+Kubernetes Development Kit (KDK)
 ===
 
 This Dockerized KDK has only been tested with OSX.  If you need Windows10
@@ -48,7 +48,7 @@ brew cask install keybase
 open https://docs.docker.com/docker-for-mac/install/
 ```
 
-### (UNTESTED, DO NOT USE) Windows Specific Setup Instructions
+### Windows Specific Setup Instructions
 
 ```bash
 # Open a Windows Powershell
@@ -61,6 +61,8 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.We
 #   If you are a Keybase user, the KeybaseFS may be mounted directly into the docker image.
 choco.exe install -y keybase openssh git curl
 ```
+
+* Download and install docker from [here](https://docs.docker.com/docker-for-windows/release-notes/)
 
 ## Dependencies Configuration
 
@@ -123,17 +125,20 @@ cd ~/
 OSX: mkdir ~/Dev; cd ~/Dev
 Windows: <Ignore This>
 
-# Start ssh-agent and load your key
-eval `ssh-agent`
-ssh-add ~/.ssh/id_rsa
-ssh-add -l  # verify that the key has been loaded
+
 
 # Download the binary for your kdk (OSX)
-curl -sSL https://github.com/cisco-sso/kdk/releases/download/0.5.2/kdk-0.5.2-darwin-amd64.tar.gz \
+curl -sSL https://github.com/cisco-sso/kdk/releases/download/0.5.3/kdk-0.5.3-darwin-amd64.tar.gz \
   | tar xz && chmod +x darwin-amd64/kdk && sudo mv darwin-amd64/kdk /usr/local/bin/kdk && rm -rf darwin-amd64
 
 # Create your ~/.kdk/config.yaml
 kdk init
+
+# Start ssh-agent and load your key
+eval `ssh-agent`
+ssh-add ~/.kdk/ssh/id_rsa
+ssh-add -l  # verify that the key has been loaded
+
 
 # Edit your ~/.kdk/config.yaml with additional volume mounts if you would like
 #   to mount host directories into the docker machine.  Additional volume bind
@@ -149,6 +154,9 @@ kdk init
 ## Use the KDK
 
 ```bash
+# Pull the latest KDK image
+kdk pull
+
 # Start the KDK
 kdk up
 
@@ -244,7 +252,7 @@ direnv allow
 
 ```bash
 # Re-install by downloading the latest binary (OSX)
-curl -sSL https://github.com/cisco-sso/kdk/releases/download/0.5.2/kdk-0.5.2-darwin-amd64.tar.gz \
+curl -sSL https://github.com/cisco-sso/kdk/releases/download/0.5.3/kdk-0.5.3-darwin-amd64.tar.gz \
   | tar xz && chmod +x darwin-amd64/kdk && sudo mv darwin-amd64/kdk /usr/local/bin/kdk && rm -rf darwin-amd64
 
 # Download the latest image
@@ -258,12 +266,6 @@ kdk up
 It is often useful to save a snapshot of the vagrant machine.
 
 TODO: Finish this section
-
-```
-# Halt before saving snapshots
-kdk snapshot
-kdk snapshot list
-```
 
 ## Building the KDK from scratch
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -29,6 +29,7 @@ var initCmd = &cobra.Command{
 
 		kdk.InitKdkConfig(*logger)
 		kdk.InitKdkSshKeyPair(*logger)
+		logger.Infof("KDK config written to %s. Modify this file to suit your needs.", kdk.ConfigPath)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/cisco-sso/kdk/internal/app/kdk"
@@ -31,6 +31,7 @@ import (
 var (
 	versionNumber string
 	cfgFile       string
+	verbose       bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -56,13 +57,15 @@ func Execute() {
 }
 
 func init() {
-	versionNumber = "0.5.2"
+	versionNumber = "0.5.3"
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.kdk.yaml)")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 }
 
 func initConfig() {
+	kdk.Verbose = verbose
 
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
@@ -74,9 +77,12 @@ func initConfig() {
 			os.Exit(1)
 		}
 
-		kdk.ConfigDir = path.Join(home, ".kdk")
+		kdk.ConfigDir = filepath.Join(home, ".kdk")
 		kdk.ConfigName = "config"
-		kdk.ConfigPath = path.Join(kdk.ConfigDir, kdk.ConfigName+".yaml")
+		kdk.ConfigPath = filepath.Join(kdk.ConfigDir, kdk.ConfigName+".yaml")
+		kdk.KeypairDir = filepath.Join(kdk.ConfigDir, "ssh")
+		kdk.PrivateKeyPath = filepath.Join(kdk.KeypairDir, "id_rsa")
+		kdk.PublicKeyPath = filepath.Join(kdk.KeypairDir, "id_rsa.pub")
 
 		if _, err := os.Stat(kdk.ConfigDir); os.IsNotExist(err) {
 			err = os.Mkdir(kdk.ConfigDir, 0700)

--- a/files/usr/local/bin/provision-user
+++ b/files/usr/local/bin/provision-user
@@ -4,14 +4,32 @@ set -euo pipefail
 OS=$(grep "^ID" /etc/os-release | cut -d= -f2)  # debian | centos
 SUDO_GROUP=$([ "$OS" == "debian" ] && echo "sudo" || echo "wheel")
 
-if [ ! -f "/etc/kdk/provisioned" ]; then
-    useradd ${KDK_USERNAME} -m -G ${SUDO_GROUP},docker -s ${KDK_SHELL} > /dev/null 2>&1
+if [[ ! -f "/etc/kdk/provisioned" ]]; then
+    # Check if user exists. If not, create
+    if ! getent passwd ${KDK_USERNAME} > /dev/null 2>&1; then
+      useradd ${KDK_USERNAME} -m -G ${SUDO_GROUP},docker -s ${KDK_SHELL} > /dev/null 2>&1
+    fi
+    # Check if .ssh dir exists
+    if [[ ! -d /home/${KDK_USERNAME}/.ssh/ ]]; then
+      install -d -o ${KDK_USERNAME} -g ${KDK_USERNAME} -m 0700 /home/${KDK_USERNAME}/.ssh
+    fi
+
+    # Check if ~/.ssh/authorized_keys exists. If not and /tmp/id_rsa.pub exists then cp
+    if [[ ! -f /home/${KDK_USERNAME}/.ssh/authorized_keys ]]; then
+      if [[ -f /tmp/id_rsa.pub ]]; then
+        install -o ${KDK_USERNAME} -g ${KDK_USERNAME} -m 0700 /tmp/id_rsa.pub /home/${KDK_USERNAME}/.ssh/authorized_keys
+        else
+          echo "Public key file not found at /tmp/id_rsa.pub"
+          exit 1
+        fi
+    fi
     chown ${KDK_USERNAME}:${KDK_USERNAME} /home/${KDK_USERNAME}
     chown -R ${KDK_USERNAME}:${KDK_USERNAME} /home/${KDK_USERNAME}/.ssh
+    chmod -R 0600 /home/${KDK_USERNAME}/.ssh/*
     install -m 0600 -o ${KDK_USERNAME} /dev/null /var/log/kdk-provision.log
 
     # Set no password for sudo users
-    if [ "$OS" == "debian" ]; then
+    if [[ "$OS" == "debian" ]]; then
       sed -i 's@\%sudo\tALL=(ALL:ALL) ALL@\%sudo\tALL=(ALL) NOPASSWD:ALL@g' /etc/sudoers
     else
       sed -i 's@^# %wheel@%wheel@g' /etc/sudoers

--- a/install
+++ b/install
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION=$(curl -sSL https://raw.githubusercontent.com/cisco-sso/kdk/master/cmd/root.go | grep -e 'versionNumber' | grep "[0-9]" | sed 's|.*"\(.*\)"|\1|g')
+
+ARCHTYPE=$(uname -m)
+if [[ ${ARCHTYPE} == 'x86_64' ]]; then
+  ARCH="amd64"
+elif [[ ${ARCHTYPE}  == 'x86_32' ]]; then
+  ARCH="386"
+else
+  echo "Unsupported architecture"
+  exit 1
+fi
+
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  OS="linux"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  OS="darwin"
+elif [[ "$OSTYPE" =~ ^(cygwin|msys)$ ]]; then
+  OS="windows"
+else
+  echo "Unsupported OS"
+  exit 1
+fi
+
+DIST_TGZ=kdk-${VERSION}-${OS}-${ARCH}.tar.gz
+
+DOWNLOAD_URI=https://github.com/cisco-sso/kdk/releases/download/${VERSION}/${DIST_TGZ}
+
+if [[ $OS == "windows" ]]; then
+  KDK_DESTINATION=/usr/bin/kdk
+elif [[ ${OS} =~ ^(linux|darwin)$ ]]; then
+  KDK_DESTINATION=/usr/local/bin/kdk
+fi
+
+curl -sSL ${DOWNLOAD_URI} | tar -C /tmp -xz
+if [[ $OS == "windows" ]]; then
+  mv /tmp/${OS}-${ARCH}/kdk.exe ${KDK_DESTINATION}
+elif [[ ${OS} =~ ^(linux|darwin)$ ]]; then
+  if [[ $EUID -ne 0 ]]; then
+     echo "This script must be run as root, use sudo $0 instead" 1>&2
+     exit 1
+  fi
+  mv /tmp/${OS}-${ARCH}/kdk /usr/local/bin/ && chmod a+x ${KDK_DESTINATION}
+fi
+
+rm -fr /tmp/${OS}-${ARCH}
+
+exit 0

--- a/install
+++ b/install
@@ -1,50 +1,50 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION=$(curl -sSL https://raw.githubusercontent.com/cisco-sso/kdk/master/cmd/root.go | grep -e 'versionNumber' | grep "[0-9]" | sed 's|.*"\(.*\)"|\1|g')
+version=$(curl -sSL https://raw.githubusercontent.com/cisco-sso/kdk/master/cmd/root.go | grep -e 'versionNumber' | grep "[0-9]" | sed 's|.*"\(.*\)"|\1|g')
 
-ARCHTYPE=$(uname -m)
-if [[ ${ARCHTYPE} == 'x86_64' ]]; then
-  ARCH="amd64"
-elif [[ ${ARCHTYPE}  == 'x86_32' ]]; then
-  ARCH="386"
+archtype=$(uname -m)
+if [[ ${archtype} == 'x86_64' ]]; then
+  arch="amd64"
+elif [[ ${archtype}  == 'x86_32' ]]; then
+  arch="386"
 else
   echo "Unsupported architecture"
   exit 1
 fi
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
-  OS="linux"
+  os="linux"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-  OS="darwin"
+  os="darwin"
 elif [[ "$OSTYPE" =~ ^(cygwin|msys)$ ]]; then
-  OS="windows"
+  os="windows"
 else
   echo "Unsupported OS"
   exit 1
 fi
 
-DIST_TGZ=kdk-${VERSION}-${OS}-${ARCH}.tar.gz
-
-DOWNLOAD_URI=https://github.com/cisco-sso/kdk/releases/download/${VERSION}/${DIST_TGZ}
-
-if [[ $OS == "windows" ]]; then
-  KDK_DESTINATION=/usr/bin/kdk
-elif [[ ${OS} =~ ^(linux|darwin)$ ]]; then
-  KDK_DESTINATION=/usr/local/bin/kdk
+if [[ ${os} =~ ^(linux|darwin)$ ]]; then
+  kdk_bin=/tmp/${os}-${arch}/kdk
+  kdk_destination=/usr/local/bin/kdk
+elif [[ $os == "windows" ]]; then
+  kdk_bin=/tmp/${os}-${arch}/kdk.exe
+  kdk_destination=/usr/bin/kdk
 fi
 
-curl -sSL ${DOWNLOAD_URI} | tar -C /tmp -xz
-if [[ $OS == "windows" ]]; then
-  mv /tmp/${OS}-${ARCH}/kdk.exe ${KDK_DESTINATION}
-elif [[ ${OS} =~ ^(linux|darwin)$ ]]; then
+if [[ ${os} =~ ^(linux|darwin)$ ]]; then
   if [[ $EUID -ne 0 ]]; then
-     echo "This script must be run as root, use sudo $0 instead" 1>&2
+     echo "This script must be run as root" 1>&2
      exit 1
   fi
-  mv /tmp/${OS}-${ARCH}/kdk /usr/local/bin/ && chmod a+x ${KDK_DESTINATION}
 fi
 
-rm -fr /tmp/${OS}-${ARCH}
+dist_tgz=kdk-${version}-${os}-${arch}.tar.gz
+download_uri=https://github.com/cisco-sso/kdk/releases/download/${version}/${dist_tgz}
 
-exit 0
+curl -sSL ${download_uri} | tar -C /tmp -xz
+
+chmod a+x ${kdk_bin}
+mv ${kdk_bin} ${kdk_destination}
+
+rm -fr /tmp/${os}-${arch}

--- a/internal/app/kdk/init.go
+++ b/internal/app/kdk/init.go
@@ -19,7 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/user"
-	"path"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/cisco-sso/kdk/internal/pkg/utils"
@@ -31,6 +31,10 @@ var (
 	ConfigDir        string
 	ConfigName       string
 	ConfigPath       string
+	Verbose          bool
+	KeypairDir       string
+	PrivateKeyPath   string
+	PublicKeyPath    string
 	ImageCoordinates string
 	Name             string
 	Port             string
@@ -41,6 +45,12 @@ var (
 func InitKdkConfig(logger logrus.Entry) error {
 
 	currentUser, _ := user.Current()
+
+	username := currentUser.Username
+
+	if strings.Contains(username, "\\") {
+		username = strings.Split(username, "\\")[1]
+	}
 
 	configTemplate := `image:
   repository: {{ .imageRepository }}
@@ -54,8 +64,8 @@ docker:
     KDK_USERNAME: {{ .username }}
     KDK_PORT: "{{ .port }}"
   binds:
-    - source: /Users/{{ .username }}/.kdk/ssh/id_rsa.pub
-      target: /home/{{ .username }}/.ssh/authorized_keys
+    - source: {{ .publicKeyPath }}
+      target: /tmp/id_rsa.pub
 `
 
 	configDefaults := map[string]interface{}{
@@ -63,7 +73,8 @@ docker:
 		"imageTag":        "debian-latest",
 		"name":            "kdk",
 		"port":            "2022",
-		"username":        currentUser.Username,
+		"publicKeyPath":   PublicKeyPath,
+		"username":        username,
 		"dotfilesRepo":    "https://github.com/cisco-sso/yadm-dotfiles.git",
 		"shell":           "/bin/bash",
 	}
@@ -94,22 +105,18 @@ docker:
 }
 
 func InitKdkSshKeyPair(logger logrus.Entry) error {
-	keypairName := "id_rsa"
-	keypairDir := path.Join(ConfigDir, "ssh")
-
-	privateKeyPath := path.Join(keypairDir, keypairName)
 
 	if _, err := os.Stat(ConfigDir); os.IsNotExist(err) {
 		if err := os.Mkdir(ConfigDir, 0700); err != nil {
 			logger.WithField("error", err).Fatal("Failed to create KDK config directory")
 		}
 	}
-	if _, err := os.Stat(keypairDir); os.IsNotExist(err) {
-		if err := os.Mkdir(keypairDir, 0700); err != nil {
+	if _, err := os.Stat(KeypairDir); os.IsNotExist(err) {
+		if err := os.Mkdir(KeypairDir, 0700); err != nil {
 			logger.WithField("error", err).Fatal("Failed to create ssh key directory")
 		}
 	}
-	if _, err := os.Stat(privateKeyPath); os.IsNotExist(err) {
+	if _, err := os.Stat(PrivateKeyPath); os.IsNotExist(err) {
 		logger.Warn("KDK ssh key pair not found.")
 		logger.Info("Generating ssh key pair...")
 		privateKey, err := utils.GeneratePrivateKey(4096)
@@ -122,12 +129,12 @@ func InitKdkSshKeyPair(logger logrus.Entry) error {
 			logger.WithField("error", err).Fatal("Failed to generate ssh public key")
 			return err
 		}
-		err = utils.WriteKeyToFile(utils.EncodePrivateKey(privateKey), privateKeyPath)
+		err = utils.WriteKeyToFile(utils.EncodePrivateKey(privateKey), PrivateKeyPath)
 		if err != nil {
 			logger.WithField("error", err).Fatal("Failed to write ssh private key")
 			return err
 		}
-		err = utils.WriteKeyToFile([]byte(publicKeyBytes), privateKeyPath+".pub")
+		err = utils.WriteKeyToFile([]byte(publicKeyBytes), PublicKeyPath)
 		if err != nil {
 			logger.WithField("error", err).Fatal("Failed to write ssh public key")
 			return err

--- a/internal/app/kdk/init.go
+++ b/internal/app/kdk/init.go
@@ -48,6 +48,7 @@ func InitKdkConfig(logger logrus.Entry) error {
 
 	username := currentUser.Username
 
+	//user.Current().Username can contain '\' on windows.
 	if strings.Contains(username, "\\") {
 		username = strings.Split(username, "\\")[1]
 	}

--- a/internal/app/kdk/pull.go
+++ b/internal/app/kdk/pull.go
@@ -21,11 +21,16 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
+	"io/ioutil"
 )
 
 func Pull(ctx context.Context, dockerClient *client.Client, imageCoordinates string) error {
 	out, err := dockerClient.ImagePull(ctx, imageCoordinates, types.ImagePullOptions{})
 	defer out.Close()
-	io.Copy(os.Stdout, out)
+	if Verbose {
+		io.Copy(os.Stdout, out)
+	} else {
+		io.Copy(ioutil.Discard, out)
+	}
 	return err
 }


### PR DESCRIPTION
- revert back to debian:9.5 image
- add user friendly outputs to init command
- add verbose flag
- use docker mounts and volumes instead of binds
- misc fixes for to support windows
- refactor provision-user script
- bump version number