### PR TITLE
WIP: Windows10 keybase mount workaround via service

### DIFF
--- a/cmd/windows.go
+++ b/cmd/windows.go
@@ -1,0 +1,93 @@
+// Copyright © 2018 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"strings"
+//	"os"
+
+	"github.com/Sirupsen/logrus"
+//	"github.com/cisco-sso/kdk/internal/app/kdk"
+	"github.com/spf13/cobra"
+)
+
+/*
+  kdk windows service run-keybase-mirror
+  kdk windows service install
+  kdk windows service remove
+*/
+
+var windowsCmd = &cobra.Command{
+	Use:   "windows",
+	Short: "Windows subcommands for KDK container",
+	Long:  `Windows subcommands KDK container`,
+	Run: func(cmd *cobra.Command, args []string) {
+		logger := logrus.New().WithField("command", "windows")
+		logger.Info("Print: " + strings.Join(args, " "))
+	},
+}
+
+var windowsServiceCmd = &cobra.Command{
+	Use:   "service",
+	Short: "Windows Service subcommands for KDK container",
+	Long:  `Windows Service subcommands KDK container`,
+	Run: func(cmd *cobra.Command, args []string) {
+		logger := logrus.New().WithField("command", "windows service")
+
+		logger.Info("Print: " + strings.Join(args, " "))
+	},
+}
+
+var windowsServiceInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Windows Service Install subcommands for KDK container",
+	Long:  `Windows Service Install subcommands KDK container`,
+	Run: func(cmd *cobra.Command, args []string) {
+		logger := logrus.New().WithField("command", "windows service install")
+
+		logger.Info("Print: " + strings.Join(args, " "))
+	},
+}
+
+var windowsServiceRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Windows Service Remove subcommands for KDK container",
+	Long:  `Windows Service Remove subcommands KDK container`,
+	Run: func(cmd *cobra.Command, args []string) {
+		logger := logrus.New().WithField("command", "windows service remove")
+
+		logger.Info("Print: " + strings.Join(args, " "))
+	},
+}
+
+var windowsServiceRunCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Windows Service Run subcommands for KDK container",
+	Long:  `Windows Service Run subcommands KDK container`,
+	Run: func(cmd *cobra.Command, args []string) {
+		logger := logrus.New().WithField("command", "windows service run")
+
+		logger.Info("Print: " + strings.Join(args, " "))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(windowsCmd)
+	windowsCmd.AddCommand(windowsServiceCmd)
+	windowsServiceCmd.AddCommand(windowsServiceInstallCmd)
+	windowsServiceCmd.AddCommand(windowsServiceRemoveCmd)
+	windowsServiceCmd.AddCommand(windowsServiceRunCmd)
+
+}

--- a/internal/app/kdk/init.go
+++ b/internal/app/kdk/init.go
@@ -93,8 +93,8 @@ func InitKdkConfig(
 
 	// Define volume bindings for the keybase directory
 	//   Linux & OSX: Detec /keybase
-	//   Windows10: Detect k: and /k
-	keybaseRoots := []string{"/keybase", "k:", "/k"}
+	//   Windows10: Detect /k
+	keybaseRoots := []string{"/keybase", "k:"}
 	keybaseTestSubdir := "/private"
 	keybaseFound := false
 	for _, keybaseRoot := range keybaseRoots {


### PR DESCRIPTION
@rtluckie  Here's the latest status.  The KDK fails to mount the keybase k:\ directory on Windows.

It may be good to try to reproduce the issue.

First, verify that the kdk cannot mount k: into \keybase.

Second, verify that running mirror.exe to mirror k: into a different place c:\keybase_mirror, and then mounting c:\keybase_mirror into kdk at location /keybase does indeed work:

```
mkdir c:\keybase_mirror
cd C:\Program Files\Dokan\Dokan Library-1.1.0\sample\mirror
.\mirror.exe /r k:\ /l c:\keybase_mirror /d
```

Third, note that running the kbfsdokan.exe manually into a second location such as m: and then attempting to mount it in the kdk fails.  This confirms that it is not a permissions issue

```
https://github.com/keybase/kbfs/tree/master/kbfsdokan
kbfsdokan.exe -debug -log-to-file M:
```

So, my current thoughts are that we need to write a kdk windows service that watches for k:, and if k: exists then mirror k: into c:\keybase_mirror (it should undo the mirror if k: disappears).  As long as the c:\keybase_mirror directory exists, even if it is empty, the kdk cant start up.  Later when mirror.exe is started, stopped, or restarted it is reflected in the kdk.

/*
  kdk windows service run-keybase-mirror
  kdk windows service install
  kdk windows service remove
*/

The "kdk windows service install" installs the service, which calls "kdk windows service run-keybase-mirror".  Remove will remove it.
