### PR TITLE
Enable auto-versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PKG       := $(shell dep ensure)
 TAGS      :=
 TESTS     := .
 TESTFLAGS :=
-LDFLAGS   := -w -s
+LDFLAGS   := -w -s -X main.Version=$(shell git describe --tags --long --dirty | sed 's/-/+/2')
 GOFLAGS   :=
 BINDIR    := $(CURDIR)/bin
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,6 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	kdk.Version = "0.7.0"
 	rootCmd.PersistentFlags().StringVar(&KdkName, "name", "kdk", "KDK name")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 }

--- a/main.go
+++ b/main.go
@@ -14,8 +14,14 @@
 
 package main
 
-import "github.com/cisco-sso/kdk/cmd"
+import (
+	"github.com/cisco-sso/kdk/cmd"
+	"github.com/cisco-sso/kdk/internal/app/kdk"
+)
+
+var Version string = "undefined"
 
 func main() {
+	kdk.Version = Version
 	cmd.Execute()
 }


### PR DESCRIPTION
* `go build` and `go install` will result in `kdk version`=="undefined"
* `make build build-cross` will result in `kdk version` being set
   as: `<latest_tag_version>(-optional_num_commits)+<git-commit>(-optional_git_status)`
   example: 0.7.0                   # where branch head equals the tag with no changes
   example: 0.7.0-1+gdcd50f0        # where branch head is beyond last tag by 2 commits
   example: 0.7.0-0+gb2842cd-dirty  # where branch head is beyond last tag by 1 commit
                                    #   with unsubmitted changes