### PR TITLE
Update cmd enhancements

### DIFF
--- a/cmd/kdk/destroy.go
+++ b/cmd/kdk/destroy.go
@@ -27,7 +27,7 @@ var destroyCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := logrus.New().WithField("command", "destroy")
 
-		kdk.Destroy(CurrentKdkEnvConfig, *logger)
+		kdk.Destroy(CurrentKdkEnvConfig, Debug, *logger)
 	},
 }
 

--- a/cmd/kdk/init.go
+++ b/cmd/kdk/init.go
@@ -27,8 +27,8 @@ var initCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := logrus.New().WithField("command", "init")
 
-		CurrentKdkEnvConfig.CreateKdkConfig(*logger)
-		CurrentKdkEnvConfig.CreateKdkSshKeyPair(*logger)
+		CurrentKdkEnvConfig.CreateKdkConfig(Debug, *logger)
+		CurrentKdkEnvConfig.CreateKdkSshKeyPair(Debug, *logger)
 		logger.Infof("KDK config written to %s. Modify this file to suit your needs.", CurrentKdkEnvConfig.ConfigPath())
 	},
 }

--- a/cmd/kdk/kdk.go
+++ b/cmd/kdk/kdk.go
@@ -25,7 +25,11 @@ import (
 	"github.com/spf13/viper"
 )
 
-var CurrentKdkEnvConfig = kdk.KdkEnvConfig{}
+var (
+	CurrentKdkEnvConfig = kdk.KdkEnvConfig{}
+	SkipUpdate          = false
+	Debug               = false
+)
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -54,7 +58,8 @@ func init() {
 	CurrentKdkEnvConfig.Init()
 
 	rootCmd.PersistentFlags().StringVar(&CurrentKdkEnvConfig.ConfigFile.AppConfig.Name, "name", "kdk", "KDK name")
-	rootCmd.PersistentFlags().BoolVarP(&CurrentKdkEnvConfig.ConfigFile.AppConfig.Debug, "debug", "d", false, "Debug Mode")
+	rootCmd.PersistentFlags().BoolVarP(&SkipUpdate, "skip-update", "", false, "Skip update")
+	rootCmd.PersistentFlags().BoolVarP(&Debug, "debug", "d", false, "Debug Mode")
 }
 
 func initConfig() {

--- a/cmd/kdk/provision.go
+++ b/cmd/kdk/provision.go
@@ -27,7 +27,7 @@ var provisionCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := logrus.New().WithField("command", "provision")
 
-		kdk.Provision(CurrentKdkEnvConfig, *logger)
+		kdk.Provision(CurrentKdkEnvConfig, Debug, *logger)
 	},
 }
 

--- a/cmd/kdk/prune.go
+++ b/cmd/kdk/prune.go
@@ -26,7 +26,7 @@ var pruneCmd = &cobra.Command{
 	Long:  `Prune unused KDK container images`,
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := logrus.New().WithField("command", "prune")
-		kdk.Prune(CurrentKdkEnvConfig, *logger)
+		kdk.Prune(CurrentKdkEnvConfig, Debug, *logger)
 	},
 }
 

--- a/cmd/kdk/pull.go
+++ b/cmd/kdk/pull.go
@@ -28,7 +28,7 @@ var pullCmd = &cobra.Command{
 		logger := logrus.New().WithField("command", "pull")
 
 		logger.Info("Pulling KDK image. This may take a moment...")
-		if err := kdk.Pull(CurrentKdkEnvConfig); err != nil {
+		if err := kdk.Pull(CurrentKdkEnvConfig, Debug); err != nil {
 			logger.WithField("error", err).Fatal("Failed to pull KDK image")
 		}
 		logger.Info("Successfully pulled KDK image.")

--- a/cmd/kdk/snapshot.go
+++ b/cmd/kdk/snapshot.go
@@ -27,7 +27,7 @@ var snapshotCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := logrus.New().WithField("command", "snapshot")
 
-		kdk.Snapshot(CurrentKdkEnvConfig, *logger)
+		kdk.Snapshot(CurrentKdkEnvConfig, Debug, *logger)
 	},
 }
 

--- a/cmd/kdk/ssh.go
+++ b/cmd/kdk/ssh.go
@@ -27,7 +27,7 @@ var sshCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := logrus.New().WithField("command", "ssh")
 
-		kdk.Ssh(CurrentKdkEnvConfig, *logger)
+		kdk.Ssh(CurrentKdkEnvConfig, Debug, SkipUpdate, *logger)
 
 	},
 }

--- a/cmd/kdk/up.go
+++ b/cmd/kdk/up.go
@@ -27,8 +27,8 @@ var upCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := logrus.New().WithField("command", "up")
 
-		kdk.Up(CurrentKdkEnvConfig, *logger)
-		kdk.Provision(CurrentKdkEnvConfig, *logger)
+		kdk.Up(CurrentKdkEnvConfig, Debug, SkipUpdate, *logger)
+		kdk.Provision(CurrentKdkEnvConfig, Debug, *logger)
 	},
 }
 

--- a/cmd/kdk/update.go
+++ b/cmd/kdk/update.go
@@ -26,7 +26,8 @@ var updateCmd = &cobra.Command{
 	Long:  `Update KDK image and binary`,
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := logrus.New().WithField("command", "update")
-		kdk.Update(CurrentKdkEnvConfig, *logger)
+
+		kdk.Update(CurrentKdkEnvConfig, Debug, SkipUpdate, *logger)
 	},
 }
 

--- a/pkg/kdk/config.go
+++ b/pkg/kdk/config.go
@@ -61,7 +61,6 @@ type AppConfig struct {
 	ImageTag        string
 	DotfilesRepo    string
 	Shell           string
-	Debug           bool
 }
 
 // create docker client and context for easy reuse
@@ -132,7 +131,7 @@ func (c *KdkEnvConfig) ImageCoordinates() (out string) {
 	return c.ConfigFile.AppConfig.ImageRepository + ":" + c.ConfigFile.AppConfig.ImageTag
 }
 
-func (c *KdkEnvConfig) CreateKdkConfig(logger logrus.Entry) (err error) {
+func (c *KdkEnvConfig) CreateKdkConfig(debug bool, logger logrus.Entry) (err error) {
 
 	// Initialize storage mounts/volumes
 	var mounts []mount.Mount         // hostConfig
@@ -265,7 +264,7 @@ func (c *KdkEnvConfig) CreateKdkConfig(logger logrus.Entry) (err error) {
 }
 
 // Creates KDK ssh keypair
-func (c *KdkEnvConfig) CreateKdkSshKeyPair(logger logrus.Entry) (err error) {
+func (c *KdkEnvConfig) CreateKdkSshKeyPair(debug bool, logger logrus.Entry) (err error) {
 
 	if _, err := os.Stat(c.ConfigRootDir()); os.IsNotExist(err) {
 		if err := os.Mkdir(c.ConfigRootDir(), 0700); err != nil {

--- a/pkg/kdk/destroy.go
+++ b/pkg/kdk/destroy.go
@@ -22,7 +22,7 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
-func Destroy(cfg KdkEnvConfig, logger logrus.Entry) error {
+func Destroy(cfg KdkEnvConfig, debug bool, logger logrus.Entry) error {
 
 	var containerIds []string
 

--- a/pkg/kdk/provision.go
+++ b/pkg/kdk/provision.go
@@ -19,7 +19,7 @@ import (
 	"github.com/codeskyblue/go-sh"
 )
 
-func Provision(cfg KdkEnvConfig, logger logrus.Entry) error {
+func Provision(cfg KdkEnvConfig, debug bool, logger logrus.Entry) error {
 	// TODO (rluckie): replace sh docker sdk
 	logger.Info("Starting KDK user provisioning. This may take a moment.  Hang tight...")
 	if _, err := sh.Command("docker", "exec", cfg.ConfigFile.AppConfig.Name, "/usr/local/bin/provision-user").Output(); err != nil {

--- a/pkg/kdk/prune.go
+++ b/pkg/kdk/prune.go
@@ -23,7 +23,7 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
-func Prune(cfg KdkEnvConfig, logger logrus.Entry) error {
+func Prune(cfg KdkEnvConfig, debug bool, logger logrus.Entry) error {
 	logger.Info("Starting Prune...")
 
 	var (

--- a/pkg/kdk/pull.go
+++ b/pkg/kdk/pull.go
@@ -16,16 +16,16 @@ package kdk
 
 import (
 	"io"
+	"io/ioutil"
 	"os"
 
 	"github.com/docker/docker/api/types"
-	"io/ioutil"
 )
 
-func Pull(cfg KdkEnvConfig) error {
+func Pull(cfg KdkEnvConfig, debug bool) error {
 	out, err := cfg.DockerClient.ImagePull(cfg.Ctx, cfg.ImageCoordinates(), types.ImagePullOptions{})
 	defer out.Close()
-	if cfg.ConfigFile.AppConfig.Debug {
+	if debug {
 		io.Copy(os.Stdout, out)
 	} else {
 		io.Copy(ioutil.Discard, out)

--- a/pkg/kdk/snapshot.go
+++ b/pkg/kdk/snapshot.go
@@ -22,7 +22,7 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
-func Snapshot(cfg KdkEnvConfig, logger logrus.Entry) error {
+func Snapshot(cfg KdkEnvConfig, debug bool, logger logrus.Entry) error {
 	snapshotName := cfg.ConfigFile.AppConfig.Name + "-" + strconv.Itoa(int(time.Now().UnixNano()))
 	_, err := cfg.DockerClient.ContainerCommit(cfg.Ctx, cfg.ConfigFile.AppConfig.Name, types.ContainerCommitOptions{Reference: snapshotName})
 	if err != nil {

--- a/pkg/kdk/ssh.go
+++ b/pkg/kdk/ssh.go
@@ -24,7 +24,12 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
-func Ssh(cfg KdkEnvConfig, logger logrus.Entry) {
+func Ssh(
+	cfg KdkEnvConfig,
+	debug bool,
+	skipUpdate bool,
+	logger logrus.Entry) {
+
 	logger.Info("Connecting to KDK container")
 
 	// Check if KDK container is running
@@ -50,14 +55,14 @@ func Ssh(cfg KdkEnvConfig, logger logrus.Entry) {
 	// if KDK container is not running, start it and provision KDK user
 	if !kdkRunning {
 		logger.Info("KDK is not currently running.  Starting...")
-		Up(cfg, logger)
-		Provision(cfg, logger)
+		Up(cfg, debug, skipUpdate, logger)
+		Provision(cfg, debug, logger)
 	}
 
 	// connect to KDK container via ssh
 	connectionString := cfg.User() + "@localhost"
 	commandString := fmt.Sprintf("ssh %s -A -p %s -i %s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null", connectionString, cfg.ConfigFile.AppConfig.Port, cfg.PrivateKeyPath())
-	if cfg.ConfigFile.AppConfig.Debug {
+	if debug {
 		logger.Infof("executing ssh command: %s", commandString)
 	}
 	commandMap := strings.Split(commandString, " ")

--- a/pkg/kdk/up.go
+++ b/pkg/kdk/up.go
@@ -23,7 +23,15 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
-func Up(cfg KdkEnvConfig, logger logrus.Entry) error {
+func Up(
+	cfg KdkEnvConfig,
+	debug bool,
+	skipUpdate bool,
+	logger logrus.Entry,
+) (err error) {
+	if err := Update(cfg, debug, skipUpdate, logger); err != nil {
+		logger.Fatal("Failed to update KDK")
+	}
 	containers, err := cfg.DockerClient.ContainerList(cfg.Ctx, types.ContainerListOptions{All: true})
 	if err != nil {
 		logger.WithField("error", err).Fatal("Failed to list docker containers")
@@ -51,7 +59,7 @@ func Up(cfg KdkEnvConfig, logger logrus.Entry) error {
 	}
 
 	if runtime.GOOS == "windows" {
-		if err := keybase.StartMirror(cfg.ConfigRootDir(), cfg.ConfigFile.AppConfig.Debug, logger); err != nil {
+		if err := keybase.StartMirror(cfg.ConfigRootDir(), debug, logger); err != nil {
 			logger.WithField("error", err).Fatal("Failed to start keybase mirror")
 			return err
 		}


### PR DESCRIPTION
- fix update cmd
  * Upon creation/re-creation of KDK container, check if the KDK image
    and binary are the latest version.
    - if not prompt user to update
  * If the user wants to run with the current versions of the kdkbin/image
    - they can the option `--skip-update` flag to continue using the
      current binary and current image.
  * The kdk update command will warn the user before doing anything that will;
    - download and overwrite a new kdk binary
    - pull the new kdk docker images
    - overwrite the ./.kdk/<kdk-name>/config file

- fix debug flag