### PR TITLE
Implement SocksPort in config

### DIFF
--- a/pkg/kdk/config.go
+++ b/pkg/kdk/config.go
@@ -61,6 +61,7 @@ type AppConfig struct {
 	ImageTag        string
 	DotfilesRepo    string
 	Shell           string
+	SocksPort       string
 }
 
 // create docker client and context for easy reuse

--- a/pkg/kdk/ssh.go
+++ b/pkg/kdk/ssh.go
@@ -56,9 +56,15 @@ func Ssh(cfg KdkEnvConfig) {
 		Provision(cfg)
 	}
 
+	// Build socksString
+	var socksString string
+	if cfg.ConfigFile.AppConfig.SocksPort != "" {
+		socksString = "-D " + cfg.ConfigFile.AppConfig.SocksPort
+	}
+
 	// connect to KDK container via ssh
 	connectionString := cfg.User() + "@localhost"
-	commandString := fmt.Sprintf("ssh %s -A -p %s -i %s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null", connectionString, cfg.ConfigFile.AppConfig.Port, cfg.PrivateKeyPath())
+	commandString := fmt.Sprintf("ssh %s -A -p %s -i %s %s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null", connectionString, cfg.ConfigFile.AppConfig.Port, cfg.PrivateKeyPath(), socksString)
 	log.Debugf("executing ssh command: %s", commandString)
 	commandMap := strings.Split(commandString, " ")
 	if err := sh.Command(commandMap[0], commandMap[1:]).SetStdin(os.Stdin).Run(); err != nil {


### PR DESCRIPTION
Tested locally on Mac.

snippet from my kdk config

```
AppConfig:
  DotfilesRepo: https://github.com/cisco-sso/yadm-dotfiles.git
  ImageRepository: ciscosso/kdk
  ImageTag: 0.9.9
  Name: kdk
  Port: "52851"
  Shell: /bin/bash
  SocksPort: "8080"
```