### PR TITLE
[drone] making both the version 1.0.0 and 0.8.6 available and creating soft link to latest

### DIFF
--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -176,7 +176,10 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
         chmod a+x direnv && mv direnv /usr/local/bin && \
     echo "Install drone-cli." && \
         curl -sSL https://github.com/drone/drone-cli/releases/download/v0.8.6/drone_linux_amd64.tar.gz | tar xz && \
-        chmod a+x drone && mv drone /usr/local/bin && \
+        chmod a+x drone && mv drone /usr/local/bin/drone-0.8.6 && \
+        curl -sSL https://github.com/drone/drone-cli/releases/download/v1.0.0/drone_linux_amd64.tar.gz | tar xz && \
+        chmod a+x drone && mv drone /usr/local/bin/drone-1.0.0 && \
+        ln -s /usr/local/bin/drone-1.0.0 /usr/local/bin/drone && \
     echo "Install easy-rsa." && \
         curl -sSL https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.5/EasyRSA-nix-3.0.5.tgz | tar xz && \
         chmod a+x EasyRSA-* && mv EasyRSA-* /usr/local/bin/easyrsa && \


### PR DESCRIPTION
Thanks @dcwangmit01 ! I have now addressed the comments in https://github.com/cisco-sso/kdk/pull/107

I need to release it as drone CLI is broken in latest `KDK`