### PR TITLE
Fix install of goreleaser

### DIFF
--- a/scripts/cicd.sh
+++ b/scripts/cicd.sh
@@ -96,7 +96,8 @@ deps() {
         go get -u github.com/mitchellh/gox
     fi
     if ! which goreleaser &>/dev/null; then
-        go get -u github.com/goreleaser/goreleaser
+        curl -sSLO https://github.com/goreleaser/goreleaser/releases/download/v0.93.2/goreleaser_Linux_x86_64.tar.gz
+        tar -C $GOPATH/bin -xzf goreleaser*.tar.gz goreleaser && rm goreleaser*.tar.gz
     fi
 
     dep ensure


### PR DESCRIPTION
* Current goreleaser install uses HEAD, which is broken right now
* Use the binary install of goreleaser