### PR TITLE
Remove deprecated 1.9.2 kops and add 1.11.0

### DIFF
--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -243,11 +243,11 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
         curl -sSLo jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
         chmod a+x jq && mv jq /usr/local/bin/ && \
     echo "Install kops." && \
-        curl -sSLo kops-1.9.2 https://github.com/kubernetes/kops/releases/download/1.9.2/kops-linux-amd64 && \
-        chmod a+x kops-1.9.2 && mv kops-1.9.2 /usr/local/bin/ && \
         curl -sSLo kops-1.10.0 https://github.com/kubernetes/kops/releases/download/1.10.0/kops-linux-amd64 && \
         chmod a+x kops-1.10.0 && mv kops-1.10.0 /usr/local/bin/ && \
-        ln -s /usr/local/bin/kops-1.10.0 /usr/local/bin/kops && \
+        curl -sSLo kops-1.11.0 https://github.com/kubernetes/kops/releases/download/1.11.0/kops-linux-amd64 && \
+        chmod a+x kops-1.11.0 && mv kops-1.11.0 /usr/local/bin/ && \
+        ln -s /usr/local/bin/kops-1.11.0 /usr/local/bin/kops && \
     echo "Install kubectl." && \
         curl -sSLo /usr/local/bin/kubectl-1.10.10 https://storage.googleapis.com/kubernetes-release/release/v1.10.10/bin/linux/amd64/kubectl && \
         curl -sSLo /usr/local/bin/kubectl-1.11.4 https://storage.googleapis.com/kubernetes-release/release/v1.11.4/bin/linux/amd64/kubectl && \


### PR DESCRIPTION
This PR removes old deprecated kops version and adds the latest stable version.