### PR TITLE
Tool updates

### DIFF
--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -235,7 +235,7 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
           chmod a+x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helm-2.12.3 && rm -fr linux-amd64 && \
         ln -s /usr/local/bin/helm-2.12.3 /usr/local/bin/helm && \
     echo "Install hugo." && \
-        curl -sSL https://github.com/gohugoio/hugo/releases/download/v0.51/hugo_0.51_Linux-64bit.tar.gz | tar xz && \
+        curl -sSL https://github.com/gohugoio/hugo/releases/download/v0.54.0/hugo_0.54.0_Linux-64bit.tar.gz | tar xz && \
         chmod a+x hugo && mv hugo /usr/local/bin/hugo && \
     echo "Install jq." && \
         curl -sSLo jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -227,7 +227,7 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
         curl -sSLO https://github.com/goreleaser/goreleaser/releases/download/v0.101.0/goreleaser_Linux_x86_64.tar.gz && \
         tar -C /usr/local/bin -xzf goreleaser*.tar.gz goreleaser && rm goreleaser*.tar.gz && \
     echo "Install grpcurl." && \
-        curl -sSL https://github.com/fullstorydev/grpcurl/releases/download/v1.0.0/grpcurl_1.0.0_linux_x86_64.tar.gz | tar -C /usr/local/bin -xz grpcurl && chmod a+x /usr/local/bin/grpcurl && \
+        curl -sSL https://github.com/fullstorydev/grpcurl/releases/download/v1.1.0/grpcurl_1.1.0_linux_x86_64.tar.gz | tar -C /usr/local/bin -xz grpcurl && chmod a+x /usr/local/bin/grpcurl && \
     echo "Install helm." && \
         curl -sSL https://storage.googleapis.com/kubernetes-helm/helm-v2.9.1-linux-amd64.tar.gz | tar xz && \
           chmod a+x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helm-2.9.1 && rm -fr linux-amd64 && \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -258,7 +258,7 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
         unzip -qq kubetail.zip && chmod a+x kubetail-1.6.7/kubetail && mv kubetail-1.6.7/kubetail /usr/local/bin && \
         rm -f kubetail.zip && \
     echo "Install mc." && \
-        curl -sSLo /usr/local/bin/mc https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2018-11-06T01-12-20Z && \
+        curl -sSLo /usr/local/bin/mc https://dl.minio.io/client/mc/release/linux-amd64/mc.RELEASE.2019-02-20T22-21-50Z && \
         chmod a+x /usr/local/bin/mc && \
     echo "Install minikube." && \
         curl -sSLo minikube https://storage.googleapis.com/minikube/releases/v0.28.2/minikube-linux-amd64 && \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -224,7 +224,7 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
         curl -sSL https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -xz && \
         mkdir -p /go && chmod a+rw /go && \
     echo "Install goreleaser." && \
-        curl -sSLO https://github.com/goreleaser/goreleaser/releases/download/v0.93.2/goreleaser_Linux_x86_64.tar.gz && \
+        curl -sSLO https://github.com/goreleaser/goreleaser/releases/download/v0.101.0/goreleaser_Linux_x86_64.tar.gz && \
         tar -C /usr/local/bin -xzf goreleaser*.tar.gz goreleaser && rm goreleaser*.tar.gz && \
     echo "Install grpcurl." && \
         curl -sSL https://github.com/fullstorydev/grpcurl/releases/download/v1.0.0/grpcurl_1.0.0_linux_x86_64.tar.gz | tar -C /usr/local/bin -xz grpcurl && chmod a+x /usr/local/bin/grpcurl && \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -185,7 +185,7 @@ RUN echo "Install python-based utils and libs" && \
          'openshift==0.7.1' \
          'passlib==1.7.1' \
          'peru==1.2.0' \
-         'pipenv' \
+         'pipenv==2018.11.26' \
          'python-neutronclient==6.10.0' \
          'python-octaviaclient==1.7.0' \
          'python-openstackclient==3.16.1' \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -221,7 +221,7 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
         curl -sSLo gomplate https://github.com/hairyhenderson/gomplate/releases/download/v3.2.0/gomplate_linux-amd64 && \
         chmod a+x gomplate && mv gomplate /usr/local/bin && \
     echo "Install golang." && \
-        curl -sSL https://dl.google.com/go/go1.11.2.linux-amd64.tar.gz | tar -C /usr/local -xz && \
+        curl -sSL https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -xz && \
         mkdir -p /go && chmod a+rw /go && \
     echo "Install goreleaser." && \
         curl -sSLO https://github.com/goreleaser/goreleaser/releases/download/v0.93.2/goreleaser_Linux_x86_64.tar.gz && \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -213,7 +213,7 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
         chmod a+x drone && mv drone /usr/local/bin/drone-1.0.0 && \
         ln -s /usr/local/bin/drone-1.0.0 /usr/local/bin/drone && \
     echo "Install easy-rsa." && \
-        curl -sSL https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.5/EasyRSA-nix-3.0.5.tgz | tar xz && \
+        curl -sSL https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.6/EasyRSA-nix-3.0.6.tgz | tar xz && \
         chmod a+x EasyRSA-* && mv EasyRSA-* /usr/local/bin/easyrsa && \
     echo "Install go-task." && \
         curl -sSL https://github.com/go-task/task/releases/download/v2.2.0/task_linux_amd64.tar.gz | tar -C /usr/local/bin -xz task && chmod a+x /usr/local/bin/task && \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -221,7 +221,7 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
         curl -sSLo gomplate https://github.com/hairyhenderson/gomplate/releases/download/v3.2.0/gomplate_linux-amd64 && \
         chmod a+x gomplate && mv gomplate /usr/local/bin && \
     echo "Install golang." && \
-        curl -sSL https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -xz && \
+        curl -sSL https://dl.google.com/go/go1.12.linux-amd64.tar.gz | tar -C /usr/local -xz && \
         mkdir -p /go && chmod a+rw /go && \
     echo "Install goreleaser." && \
         curl -sSLO https://github.com/goreleaser/goreleaser/releases/download/v0.101.0/goreleaser_Linux_x86_64.tar.gz && \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -362,7 +362,7 @@ RUN echo "Install zsh." && \
     ./configure --with-tcsetpgrp --prefix=/usr/local && make && make install && echo "/usr/local/bin/zsh" >> /etc/shells && cd .. && rm -fr zsh-*
 
 RUN echo "Install redis-cli tools." && \
-    curl -sSL http://download.redis.io/releases/redis-5.0.0.tar.gz | tar xz && cd redis-* && \
+    curl -sSL http://download.redis.io/releases/redis-5.0.3.tar.gz | tar xz && cd redis-* && \
     make && cp src/redis-cli src/redis-benchmark /usr/local/bin && cd .. && rm -fr redis-*
 
 

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -247,11 +247,12 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
         chmod a+x kops-1.11.0 && mv kops-1.11.0 /usr/local/bin/ && \
         ln -s /usr/local/bin/kops-1.11.0 /usr/local/bin/kops && \
     echo "Install kubectl." && \
-        curl -sSLo /usr/local/bin/kubectl-1.10.10 https://storage.googleapis.com/kubernetes-release/release/v1.10.10/bin/linux/amd64/kubectl && \
-        curl -sSLo /usr/local/bin/kubectl-1.11.4 https://storage.googleapis.com/kubernetes-release/release/v1.11.4/bin/linux/amd64/kubectl && \
-        curl -sSLo /usr/local/bin/kubectl-1.12.2 https://storage.googleapis.com/kubernetes-release/release/v1.12.2/bin/linux/amd64/kubectl && \
+        curl -sSLo /usr/local/bin/kubectl-1.10.13 https://storage.googleapis.com/kubernetes-release/release/v1.10.13/bin/linux/amd64/kubectl && \
+        curl -sSLo /usr/local/bin/kubectl-1.11.7 https://storage.googleapis.com/kubernetes-release/release/v1.11.7/bin/linux/amd64/kubectl && \
+        curl -sSLo /usr/local/bin/kubectl-1.12.6 https://storage.googleapis.com/kubernetes-release/release/v1.12.6/bin/linux/amd64/kubectl && \
+        curl -sSLo /usr/local/bin/kubectl-1.13.3 https://storage.googleapis.com/kubernetes-release/release/v1.13.3/bin/linux/amd64/kubectl && \
         chmod a+x /usr/local/bin/kubectl-* && \
-        ln -s /usr/local/bin/kubectl-1.12.2 /usr/local/bin/kubectl && \
+        ln -s /usr/local/bin/kubectl-1.13.3 /usr/local/bin/kubectl && \
     echo "Install kubetail." && \
         curl -sSLo kubetail.zip https://github.com/johanhaleby/kubetail/archive/1.6.5.zip && \
         unzip -qq kubetail.zip && chmod a+x kubetail-1.6.5/kubetail && mv kubetail-1.6.5/kubetail /usr/local/bin && \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -254,8 +254,8 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
         chmod a+x /usr/local/bin/kubectl-* && \
         ln -s /usr/local/bin/kubectl-1.13.3 /usr/local/bin/kubectl && \
     echo "Install kubetail." && \
-        curl -sSLo kubetail.zip https://github.com/johanhaleby/kubetail/archive/1.6.5.zip && \
-        unzip -qq kubetail.zip && chmod a+x kubetail-1.6.5/kubetail && mv kubetail-1.6.5/kubetail /usr/local/bin && \
+        curl -sSLo kubetail.zip https://github.com/johanhaleby/kubetail/archive/1.6.7.zip && \
+        unzip -qq kubetail.zip && chmod a+x kubetail-1.6.7/kubetail && mv kubetail-1.6.7/kubetail /usr/local/bin && \
         rm -f kubetail.zip && \
     echo "Install mc." && \
         curl -sSLo /usr/local/bin/mc https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2018-11-06T01-12-20Z && \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -204,7 +204,7 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
         curl -sSLo dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && \
         chmod a+x dep && mv dep /usr/local/bin && \
     echo "Install direnv." && \
-        curl -sSLo direnv https://github.com/direnv/direnv/releases/download/v2.17.0/direnv.linux-amd64 && \
+        curl -sSLo direnv https://github.com/direnv/direnv/releases/download/v2.19.2/direnv.linux-amd64 && \
         chmod a+x direnv && mv direnv /usr/local/bin && \
     echo "Install drone-cli." && \
         curl -sSL https://github.com/drone/drone-cli/releases/download/v0.8.6/drone_linux_amd64.tar.gz | tar xz && \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -241,8 +241,8 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
         curl -sSLo jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
         chmod a+x jq && mv jq /usr/local/bin/ && \
     echo "Install kops." && \
-        curl -sSLo kops-1.10.0 https://github.com/kubernetes/kops/releases/download/1.10.0/kops-linux-amd64 && \
-        chmod a+x kops-1.10.0 && mv kops-1.10.0 /usr/local/bin/ && \
+        curl -sSLo kops-1.10.1 https://github.com/kubernetes/kops/releases/download/1.10.1/kops-linux-amd64 && \
+        chmod a+x kops-1.10.1 && mv kops-1.10.1 /usr/local/bin/ && \
         curl -sSLo kops-1.11.0 https://github.com/kubernetes/kops/releases/download/1.11.0/kops-linux-amd64 && \
         chmod a+x kops-1.11.0 && mv kops-1.11.0 /usr/local/bin/ && \
         ln -s /usr/local/bin/kops-1.11.0 /usr/local/bin/kops && \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -218,7 +218,7 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
     echo "Install go-task." && \
         curl -sSL https://github.com/go-task/task/releases/download/v2.4.0/task_linux_amd64.tar.gz | tar -C /usr/local/bin -xz task && chmod a+x /usr/local/bin/task && \
     echo "Install gomplate." && \
-        curl -sSLo gomplate https://github.com/hairyhenderson/gomplate/releases/download/v3.0.0/gomplate_linux-amd64 && \
+        curl -sSLo gomplate https://github.com/hairyhenderson/gomplate/releases/download/v3.2.0/gomplate_linux-amd64 && \
         chmod a+x gomplate && mv gomplate /usr/local/bin && \
     echo "Install golang." && \
         curl -sSL https://dl.google.com/go/go1.11.2.linux-amd64.tar.gz | tar -C /usr/local -xz && \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -213,7 +213,7 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
         chmod a+x drone && mv drone /usr/local/bin/drone-1.0.0 && \
         ln -s /usr/local/bin/drone-1.0.0 /usr/local/bin/drone && \
     echo "Install easy-rsa." && \
-        curl -sSL https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.6/EasyRSA-nix-3.0.6.tgz | tar xz && \
+        curl -sSL https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.6/EasyRSA-unix-v3.0.6.tgz | tar xz && \
         chmod a+x EasyRSA-* && mv EasyRSA-* /usr/local/bin/easyrsa && \
     echo "Install go-task." && \
         curl -sSL https://github.com/go-task/task/releases/download/v2.4.0/task_linux_amd64.tar.gz | tar -C /usr/local/bin -xz task && chmod a+x /usr/local/bin/task && \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -216,7 +216,7 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
         curl -sSL https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.6/EasyRSA-nix-3.0.6.tgz | tar xz && \
         chmod a+x EasyRSA-* && mv EasyRSA-* /usr/local/bin/easyrsa && \
     echo "Install go-task." && \
-        curl -sSL https://github.com/go-task/task/releases/download/v2.2.0/task_linux_amd64.tar.gz | tar -C /usr/local/bin -xz task && chmod a+x /usr/local/bin/task && \
+        curl -sSL https://github.com/go-task/task/releases/download/v2.4.0/task_linux_amd64.tar.gz | tar -C /usr/local/bin -xz task && chmod a+x /usr/local/bin/task && \
     echo "Install gomplate." && \
         curl -sSLo gomplate https://github.com/hairyhenderson/gomplate/releases/download/v3.0.0/gomplate_linux-amd64 && \
         chmod a+x gomplate && mv gomplate /usr/local/bin && \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -229,13 +229,11 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
     echo "Install grpcurl." && \
         curl -sSL https://github.com/fullstorydev/grpcurl/releases/download/v1.1.0/grpcurl_1.1.0_linux_x86_64.tar.gz | tar -C /usr/local/bin -xz grpcurl && chmod a+x /usr/local/bin/grpcurl && \
     echo "Install helm." && \
-        curl -sSL https://storage.googleapis.com/kubernetes-helm/helm-v2.9.1-linux-amd64.tar.gz | tar xz && \
-          chmod a+x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helm-2.9.1 && rm -fr linux-amd64 && \
-        curl -sSL https://storage.googleapis.com/kubernetes-helm/helm-v2.10.0-linux-amd64.tar.gz | tar xz && \
-          chmod a+x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helm-2.10.0 && rm -fr linux-amd64 && \
         curl -sSL https://storage.googleapis.com/kubernetes-helm/helm-v2.11.0-linux-amd64.tar.gz | tar xz && \
           chmod a+x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helm-2.11.0 && rm -fr linux-amd64 && \
-        ln -s /usr/local/bin/helm-2.11.0 /usr/local/bin/helm && \
+        curl -sSL https://storage.googleapis.com/kubernetes-helm/helm-v2.12.3-linux-amd64.tar.gz | tar xz && \
+          chmod a+x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helm-2.12.3 && rm -fr linux-amd64 && \
+        ln -s /usr/local/bin/helm-2.12.3 /usr/local/bin/helm && \
     echo "Install hugo." && \
         curl -sSL https://github.com/gohugoio/hugo/releases/download/v0.51/hugo_0.51_Linux-64bit.tar.gz | tar xz && \
         chmod a+x hugo && mv hugo /usr/local/bin/hugo && \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -209,7 +209,7 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
     echo "Install drone-cli." && \
         curl -sSL https://github.com/drone/drone-cli/releases/download/v0.8.6/drone_linux_amd64.tar.gz | tar xz && \
         chmod a+x drone && mv drone /usr/local/bin/drone-0.8.6 && \
-        curl -sSL https://github.com/drone/drone-cli/releases/download/v1.0.0/drone_linux_amd64.tar.gz | tar xz && \
+        curl -sSL https://github.com/drone/drone-cli/releases/download/v1.0.7/drone_linux_amd64.tar.gz | tar xz && \
         chmod a+x drone && mv drone /usr/local/bin/drone-1.0.0 && \
         ln -s /usr/local/bin/drone-1.0.0 /usr/local/bin/drone && \
     echo "Install easy-rsa." && \

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -264,7 +264,7 @@ RUN echo "Install apps (with pinned version) that are not provided by the OS pac
         curl -sSLo minikube https://storage.googleapis.com/minikube/releases/v0.28.2/minikube-linux-amd64 && \
         chmod a+x minikube &&  mv minikube /usr/local/bin/ && \
     echo "Install terraform." && \
-        curl -sSLo terraform.zip https://releases.hashicorp.com/terraform/0.11.10/terraform_0.11.10_linux_amd64.zip && \
+        curl -sSLo terraform.zip https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_amd64.zip && \
         unzip -qq terraform.zip && chmod a+x terraform && mv terraform /usr/local/bin && rm -f terraform.zip && \
     echo "Install testssl." && \
         curl -sSL https://github.com/drwetter/testssl.sh/archive/v2.9.5-7.tar.gz | tar xz && \


### PR DESCRIPTION
- Update direnv 2.17.0 -> 2.19.2
- Update drone-cli 1.0.0 -> 1.0.7
- Update easy-rsa 3.0.5 -> 3.0.6
- Update go-task 2.2.0 -> 2.4.0
- Update gomplate 3.0.0 -> 3.2.0
- Update golang 1.11.2 -> 1.12
- Update goreleaser 0.93.2 -> 0.101.0
- Update grpcurl 1.0.0 -> 1.1.0
- Update helm 2.11.0 -> 2.12.3
- Update hugo 0.51 -> 0.54.0
- Update kops 1.10.0 -> 1.10.1
- Update kubectl
- Update kubetail 1.6.5 -> 1.6.7
- Update mc (minio CLI)
- Update terraform 0.11.10 -> 0.11.11
- Pin pipenv version
- Update redis 5.0.0 -> 5.0.3