### PR TITLE
Add ability to build Vagrant images using Packer.

### DIFF
--- a/files/provision.sh
+++ b/files/provision.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo HELLO | sudo tee /opt/test.txt

--- a/packer/.gitignore
+++ b/packer/.gitignore
@@ -1,0 +1,1 @@
+output-vagrant/

--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,40 @@
+# Packer builds of KDK
+
+In addition to the Docker build of KDK, this directory enables Packer-based VM image (non-Docker) builds as well.
+
+Supported targets/hypervisors:
+
+* Vagrant
+  * VirtualBox
+
+## Validate the Packer template and build a new KDK image.
+
+```bash
+cd kdk/packer
+
+packer validate ubuntu-18.04.json
+
+packer build ubuntu-18.04.json
+```
+
+## Add the new image to Vagrant.
+
+```bash
+vagrant box add output-vagrant/package.box --name kdk/ubuntu-18.04
+```
+
+## Try the new image.
+
+```bash
+mkdir ~/vagrant/kdk
+
+cd ~/vagrant/kdk
+
+vagrant init kdk/ubuntu-18.04
+
+vagrant up
+
+vagrant ssh
+```
+
+## TODO: Publish the new image.

--- a/packer/ubuntu-18.04.json
+++ b/packer/ubuntu-18.04.json
@@ -1,0 +1,19 @@
+{
+  "builders": [
+    {
+      "type": "vagrant",
+      "provider": "virtualbox",
+      "box_name": "kdk/ubuntu-18.04",
+      "box_version": "201812.27.0",
+      "source_path": "bento/ubuntu-18.04",
+      "add_force": true,
+      "communicator": "ssh"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "../files/provision.sh"
+    }
+  ]
+}


### PR DESCRIPTION
Worked for me. Once the image is built, imported and running, try executing `sudo cat /opt/test.txt`.

Would like help testing the new readme. I ran out of time today to do thorough re-test using my own writing.