### PR TITLE
Run provision script w/sudo in vagrant. Replace tabs with spaces.

### DIFF
--- a/files/provision.sh
+++ b/files/provision.sh
@@ -5,12 +5,12 @@ function main() {
     export DEBIAN_FRONTEND="noninteractive"
 
     if [ "$#" -eq 0 ]; then
-	# If this script was called with zero args, then we build for vagrant
-	vagrant
+        # If this script was called with zero args, then we build for vagrant
+        vagrant
     else
-	# If this script was called with arguments, then we build for docker
-	#   The following expects the first argument to be the function name
-	$@
+        # If this script was called with arguments, then we build for docker
+        #   The following expects the first argument to be the function name
+        $@
     fi
 }
 

--- a/packer/ubuntu-18.04.json
+++ b/packer/ubuntu-18.04.json
@@ -13,7 +13,12 @@
   "provisioners": [
     {
       "type": "shell",
-      "script": "../files/provision.sh"
+      "script": "../files/provision.sh",
+      "override": {
+        "vagrant": {
+          "execute_command": "sudo {{.Path}}"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
This fix helps, but still hit:

```
    vagrant: Get:29 http://archive.ubuntu.com/ubuntu bionic-backports/main i386 Packages [2,516 B]
    vagrant: Get:30 http://archive.ubuntu.com/ubuntu bionic-backports/main Translation-en [1,644 B]
    vagrant: Get:31 http://archive.ubuntu.com/ubuntu bionic-backports/universe i386 Packages [3,732 B]
    vagrant: Get:32 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [3,728 B]
    vagrant: Get:33 http://archive.ubuntu.com/ubuntu bionic-backports/universe Translation-en [1,696 B]
    vagrant: Fetched 6,164 kB in 17s (364 kB/s)
    vagrant: Reading package lists...
    vagrant: Reading package lists...
    vagrant: Building dependency tree...
    vagrant: Reading state information...
==> vagrant: E: Unable to locate package libevent-2.0-5
==> vagrant: E: Couldn't find any package by glob 'libevent-2.0-5'
==> vagrant: E: Couldn't find any package by regex 'libevent-2.0-5'
==> vagrant: destroying Vagrant box...
==> vagrant: Deleting output directory...
Build 'vagrant' errored: Script exited with non-zero exit status: 100.Allowed exit codes are: [0]
```