### PR TITLE
Downgrade vbox additions and kernel

### DIFF
--- a/files/provision.sh
+++ b/files/provision.sh
@@ -42,24 +42,25 @@ function vagrant_upgrade_kernel_workaround_sshuttle_kernel_bug() {
     echo "#### ${FUNCNAME[0]}"
 
     # Install a kernel upgrade helper
+    #   Dkms will automatically recompile kmods upon kernel update
     apt-add-repository -y ppa:teejee2008/ppa
     apt-get update
     apt-get -y install dkms ukuu linux-headers-$(uname -r)
 
-    # Install a newer kernel
-    ukuu --list
-    ukuu --install v5.1.16
-    ukuu --list-installed
-
-    # Update virtualbox guest additions and rebuild kernel modules
-    wget -O /tmp/additions.iso \
-      http://download.virtualbox.org/virtualbox/6.0.10/VBoxGuestAdditions_6.0.10.iso
+    # Update virtualbox guest additions.  This will rebuild kernel modules
+    wget -q -O /tmp/additions.iso \
+      http://download.virtualbox.org/virtualbox/6.0.4/VBoxGuestAdditions_6.0.4.iso
     mkdir -p /cdrom
     mount -o loop /tmp/additions.iso /cdrom
     /cdrom/VBoxLinuxAdditions.run || true # always errors
     umount /cdrom
     rm -rf /cdrom /tmp/additions.iso
-    /sbin/rcvboxadd quicksetup all # build kernel modules for non-active but installed kernels
+
+    # Install a newer kernel
+    #   dkms will kick in and rebuild modules for this new kernel
+    ukuu --list
+    ukuu --install v4.20.17
+    ukuu --list-installed
 }
 
 function vagrant_bento_workaround_openssl_bug() {

--- a/packer/Makefile
+++ b/packer/Makefile
@@ -13,6 +13,7 @@ build_hyperv: validate  ## Build the hyperv vagrant images
 	PACKER_LOG=1 packer build packer_hyperv.json     2>&1 | tee build-hyperv.log
 
 add_box:  ## Add the box as kdk/ubuntu-18.04-test
+	vagrant box remove kdk/ubuntu-18.04-test 2>&1 > /dev/null || true
 	vagrant box add output-vagrant/package.box --name kdk/ubuntu-18.04-test --force
 
 validate:  ## Validate the packer json files


### PR DESCRIPTION
* Fixes a filesystem bug.  Vbox 6.0.10 is broken

Issue workaround of:
  https://github.com/hashicorp/vagrant/issues/10913#issuecomment-513978619

This fixes the virtualbox filesystem problems.  Downgraded the kernel to latest 4.x series.  Downgraded vbox guest additions only from 6.0.10 -> 6.0.4 .  The build env was the latest 6.0.10, but the guest additions installed are 6.0.4.  Therefore, no need to pin to an older version of virtualbox for neither builders or normal users.  You can "vagrant box update" in ksng1 to get the latest, since it's already uploaded to vagrant cloud