### PR TITLE
Fixed build failures from Github API Throttling Limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
 language: go
 go:
-  - '1.13.7'
+- 1.13.7
 go_import_path: github.com/cisco-sso/kdk
 services:
-  - docker
+- docker
 before_install:
-  - make checks
+- make checks
 script:
-  - make bin-build docker-build
+- make bin-build docker-build
 deploy:
-  - on:
-      tags: true
-    provider: script
-    script:
-      - make docker-push bin-push
-    skip_cleanup: true
+- true:
+    tags: true
+  provider: script
+  script:
+  - make docker-push bin-push
+  skip_cleanup: true
+env:
+  global:
+    secure: NIsNuvqBRhxahX1EdtJ6TreVLmM5aawVnkBolshgdWv8EQNMVT1FO64EBiWrz4ZWJSTj8DKAUfIYzetYhtIjGwEudL0yCUBLi0Bw7Tl8BKZV4wvVG0uL0qk/34erpnMY9/UP9KIOs1dR0G1daR4m1sVgW9Yjgt0K4L5G2r1t5tslUIm/S0yVUK9MuKoEGmqKmVZNpn2Q6UI/lPA1yn4cGqSp1uSUSCC1yaNMa6jtaWK4w9f0/zUXtGDaF+N8AXuhEGa777kI6yJIVrO3BjsPhQHpJH6Unku6tr5YCOoBItXCDEsl2TEHBuzgLYuivtYQvo73ZfHkuhQ8YmcEnciD3MrfAt/LqpsrmvVhnZvPhRh953m7jwxVwn6lOC46mr+le5WfXtKMahp6mTVwhmKEekD9wEhZ59xeuQd36HaYoboaEN/iWm+Xsbr9gMjhHf27BG3jL+BOvS5wSZEwhmdomijQB3QQ7qA9aWxzspuLag58TmjqFkqUyXl6+DEBzbZBsM+t5xqK0SalAhEJaC5DoBF0dFdInnR7uJ4f9nWe01Cr9qN1To5zYM9xXZtWcXPjAkzjqBTdCaq0Xgmz/u9+cYGp+Al/mUD4VxWPjmniJvQGBCzqRZeyp8xh+gKqqA0sjbP35JwnKQ66ONM8nhn6Zd2hqeyRH1r19H2uo2lUg14=

--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,9 @@ ifdef NEEDS_BUILD_DOCKER
 	@#   docker build -t $(NEW_IMAGE_TAG) --cache-from $(BASE_IMAGE):latest -f files/Dockerfile files
 	@# Our Dockerfile precludes caching because of an early COPY, so do not sweat it
 
-	@# Build the docker image as latest
-	docker build --tag $(BASE_IMAGE):latest files/
+	@# Build the docker image as latest, using a GITHUB_API_TOKEN to increase throttling limits
+	@if [[ -z "${GITHUB_API_TOKEN}" ]]; then echo "ERROR: GITHUB_API_TOKEN env var must be set: export GITHUB_API_TOKEN=(token created from https://github.com/settings/tokens)"; exit 1; fi
+	docker build --build-arg GITHUB_API_TOKEN=${GITHUB_API_TOKEN} --tag $(BASE_IMAGE):latest files/
 
 	@# Then retag as the new version
 	docker tag $(BASE_IMAGE):latest $(NEW_IMAGE_TAG)

--- a/README.md
+++ b/README.md
@@ -6,15 +6,39 @@ Kubernetes Development Kit (KDK)
 This Quickstart assumes that you have installed all of the
 [dependencies](https://github.com/cisco-sso/kdk#installation-instructions).
 
+The KDK works on many OS's, and may run as a docker container or virtual machine.
+
+* On Mac and Linux, the preferred route is to run the KDK as a docker image.
+* On Windows, the preferred route is to run the KDK as a Vagrant virtual machine (Hyper-V and Virtualbox are both supported).
+
 
 ### Mac and Linux
+
+#### Docker KDK (preferred for Mac)
 
 ```console
 curl -sSL https://raw.githubusercontent.com/cisco-sso/kdk/master/files/install | bash
 kdk init && kdk ssh
 ```
 
+#### Vagrant KDK
+
+The Vagrant Virtualbox image works on Mac, using the same instructions as the Windows version.  The only reason one may choose to use this run method is if support for IPV6 networking is required.  Docker for Mac does not support IPV6.
+
+
 ### Windows
+
+#### Vagrant Hyper-V or Virtualbox KDK (preferred for Windows)
+
+```console
+git clone git@github.com:cisco-sso/kdk.git # or https://github.com/cisco-sso/kdk.git
+cd kdk
+# Edit Vagrantfile: You may want to tune memory, network settings, or host-mounted directories.
+vagrant up  # Starts the KDK
+vagrant ssh -- -A -D 8000  # Connect to the KDK (-A ssh-agent forwarding, -D socks proxy forwarding)
+# Use the KDK
+vagrant destroy
+```
 
 #### Docker KDK
 
@@ -29,17 +53,6 @@ kdk init ; kdk ssh
 NOTE: After installation, Windows CMD prompt will work. The KDK has not been
 tested with Cygwin, Mingw, or Windows Subsystem for Linux.
 
-#### Vagrant Hyper-V or Virtualbox KDK
-
-```console
-git clone git@github.com:cisco-sso/kdk.git # or https://github.com/cisco-sso/kdk.git
-cd kdk
-# Edit Vagrantfile: You may want to tune memory, network settings, or host-mounted directories.
-vagrant up  # Starts the KDK
-vagrant ssh -- -A -D 8000  # Connect to the KDK (-A ssh-agent forwarding, -D socks proxy forwarding)
-# Use the KDK
-vagrant destroy
-```
 
 ## Installation Instructions
 

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:bionic AS build-cache-base
 
+ARG GITHUB_API_TOKEN
+
 LABEL maintainer="rluckie@cisco.com" \
       kdk=""
 
@@ -18,7 +20,7 @@ RUN /tmp/provision.sh layer_install_python_based_utils_and_libs
 #######################################
 # Install apps (with pinned version) that are not provided by the OS packages.
 
-RUN /tmp/provision.sh layer_install_apps_not_provided_by_os_packages
+RUN GITHUB_API_TOKEN=${GITHUB_API_TOKEN} /tmp/provision.sh layer_install_apps_not_provided_by_os_packages
 
 #######################################
 # go get installs

--- a/files/provision.sh
+++ b/files/provision.sh
@@ -4,30 +4,41 @@ set -euo pipefail
 function main() {
     export DEBIAN_FRONTEND="noninteractive"
     if [ "$#" -eq 0 ]; then
-        # If this script was called with zero args, then we build for ubuntu bionic
-        ubuntu_bionic
+	# If this script was called with zero args, then we build for ubuntu bionic
+	ubuntu_bionic
     else
-        # If this script was called with arguments, then we build for docker
-        #   The following expects the first argument to be the function name
-        $@
+	# If this script was called with arguments, then we build for docker
+	#   The following expects the first argument to be the function name
+	$@
     fi
 }
 
 function get_latest_github_release_version() {
     if [[ ! "$#" -eq 2 ]]; then
-        # If this function was not called with 2 args. then complain and exitcalled with zero args, then we build for ubuntu bionic
-        echo "Function must be called with 2 args (ORG and REPO)"
-        exit 1
+	# If this function was not called with 2 args. then complain and exitcalled with zero args, then we build for ubuntu bionic
+	echo "Function must be called with 2 args (ORG and REPO)"
+	exit 1
     else
-        export ORG=$1
-        export REPO=$2
-        export VERSION=$(curl -sSfL https://api.github.com/repos/"${ORG}/${REPO}"/releases/latest 2>/dev/null | grep tag_name | cut -d '"' -f 4 | sed 's|v||g')
-        if [[ -z "${VERSION}" ]]; then
-            echo "Failed to get version"
-            exit 1
-        else
-            echo "${VERSION}"
-        fi
+	ORG=$1
+	REPO=$2
+	if [[ ! -z $GITHUB_API_TOKEN ]]; then
+	    # If defined, use the Github Auth Token to increase throttling limits
+	    GITHUB_AUTH="Authorization: token $GITHUB_API_TOKEN"
+	    REQUEST=$(curl -isSfL -H "$GITHUB_AUTH" https://api.github.com/repos/"${ORG}/${REPO}"/releases/latest 2>&1)
+	else
+	    REQUEST=$(curl -isSfL https://api.github.com/repos/"${ORG}/${REPO}"/releases/latest 2>&1)
+	fi
+
+	VERSION=$(echo "$REQUEST" | grep tag_name | cut -d '"' -f 4 | sed 's|v||g')
+	# RATE_LIMIT_REMAINING=$(echo "$REQUEST" | grep X-RateLimit-Remaining | grep -v Access-Control-Expose-Headers)
+	# echo "  RATE_LIMIT_REMAINING: $RATE_LIMIT_REMAINING"
+	if [[ -z "${VERSION}" ]]; then
+	    echo "FAILED TO GET VERSION"
+	    echo "  Potential API Rate Limit Error: Please generate and set GITHUB_API_TOKEN"
+	    exit 1
+	else
+	    echo "${VERSION}"
+	fi
     fi
 }
 
@@ -66,7 +77,7 @@ function vagrant_disable_ssh_password_logins() {
     # Vagrant machines are ssh-able via user/pass vagrant/vagrant.
     #   Disable this, since some boxes may run with bridged networking by default
     sed -i 's@#PasswordAuthentication yes@PasswordAuthentication no@g' \
-        /etc/ssh/sshd_config
+	/etc/ssh/sshd_config
 }
 
 function vagrant_upgrade_kernel_workaround_sshuttle_kernel_bug() {
@@ -81,7 +92,7 @@ function vagrant_upgrade_kernel_workaround_sshuttle_kernel_bug() {
 
     # Update virtualbox guest additions.  This will rebuild kernel modules
     wget -q -O /tmp/additions.iso \
-      http://download.virtualbox.org/virtualbox/6.0.4/VBoxGuestAdditions_6.0.4.iso
+	 http://download.virtualbox.org/virtualbox/6.0.4/VBoxGuestAdditions_6.0.4.iso
     mkdir -p /cdrom
     mount -o loop /tmp/additions.iso /cdrom
     /cdrom/VBoxLinuxAdditions.run || true # always errors
@@ -108,290 +119,289 @@ function layer_install_os_packages() {
     # big items: gcc, python-dev
 
     echo "#### ${FUNCNAME[0]}"
-    apt-get -y -qq update && apt-get --no-install-recommends -y -qq install \
-        apache2-utils \
-        apt-transport-https \
-        bash-completion \
-        bc \
-        bridge-utils \
-        ca-certificates \
-        colordiff \
-        ctags \
-        curl \
-        dc \
-        dhcpdump \
-        dialog \
-        dnsmasq \
-        dnsutils \
-        dos2unix \
-        fonts-powerline \
-        fio \
-        gcc \
-        gettext \
-        gnupg \
-        gnupg2 \
-        htop \
-        iputils-ping \
-        less \
-        libcurl4-openssl-dev \
-        locales \
-        lsof \
-        make \
-        man \
-        moreutils \
-        nmap \
-        ntp \
-        ntpdate \
-        openconnect \
-        openjdk-11-jdk-headless \
-        openssh-server \
-        perl \
-        proxychains \
-        python3 \
-        python3-dev \
-        qemu-user-static \
-        ruby \
-        screen \
-        socat \
-        software-properties-common \
-        sudo \
-        systemd \
-        systemd-sysv \
-        tcl \
-        telnet \
-        traceroute \
-        tree \
-        unzip \
-        wget \
-        whois \
-        xauth \
-        zip && \
-    curl -sSfL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-       add-apt-repository \
-         "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-         $(lsb_release -cs) \
-         stable" && \
-    export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
-        echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-        curl -sSfL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    export POSTGRESQL_REPO="$(lsb_release -c -s)-pgdg" && \
-        echo "deb https://apt.postgresql.org/pub/repos/apt $POSTGRESQL_REPO main" | tee -a /etc/apt/sources.list.d/pgdg.list && \
-        curl -sSfL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    curl -sSfL https://deb.nodesource.com/setup_13.x | bash - && \
-        curl -sSfL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-        echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee -a /etc/apt/sources.list.d/yarn.list && \
-    apt-get update -y -qq && apt-get --no-install-recommends -y -qq install \
-        docker-ce \
-        google-cloud-sdk \
-        nodejs \
-        postgresql-client-10 \
-        yarn && \
-    # Add deps to enable pyenv-driven on-demand python installs on KDK \
-    apt-get --no-install-recommends -y -qq install \
-        make build-essential \
-        libssl-dev \
-        zlib1g-dev \
-        libbz2-dev \
-        libreadline-dev \
-        libsqlite3-dev \
-        wget \
-        curl \
-        llvm \
-        libncurses5-dev \
-        libncursesw5-dev \
-        xz-utils \
-        tk-dev \
-        libffi-dev \
-        liblzma-dev \
-        python3-openssl && \
-    apt-get -y -qq clean && apt-get -y -qq autoremove && rm -rf /var/lib/apt/lists/*
+    apt-get -y update && apt-get --no-install-recommends -y install \
+				 apache2-utils \
+				 apt-transport-https \
+				 bash-completion \
+				 bc \
+				 bridge-utils \
+				 ca-certificates \
+				 colordiff \
+				 ctags \
+				 curl \
+				 dc \
+				 dhcpdump \
+				 dialog \
+				 dnsmasq \
+				 dnsutils \
+				 dos2unix \
+				 fonts-powerline \
+				 fio \
+				 gcc \
+				 gettext \
+				 gnupg \
+				 gnupg2 \
+				 htop \
+				 iputils-ping \
+				 less \
+				 libcurl4-openssl-dev \
+				 locales \
+				 lsof \
+				 make \
+				 man \
+				 moreutils \
+				 nmap \
+				 ntp \
+				 ntpdate \
+				 openconnect \
+				 openjdk-11-jdk-headless \
+				 openssh-server \
+				 perl \
+				 proxychains \
+				 python3 \
+				 python3-dev \
+				 qemu-user-static \
+				 ruby \
+				 screen \
+				 socat \
+				 software-properties-common \
+				 sudo \
+				 systemd \
+				 systemd-sysv \
+				 tcl \
+				 telnet \
+				 traceroute \
+				 tree \
+				 unzip \
+				 wget \
+				 whois \
+				 xauth \
+				 zip && \
+	curl -sSfL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+	add-apt-repository \
+	    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+	 $(lsb_release -cs) \
+	 stable" && \
+	export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
+	echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+	curl -sSfL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+	export POSTGRESQL_REPO="$(lsb_release -c -s)-pgdg" && \
+	echo "deb https://apt.postgresql.org/pub/repos/apt $POSTGRESQL_REPO main" | tee -a /etc/apt/sources.list.d/pgdg.list && \
+	curl -sSfL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+	curl -sSfL https://deb.nodesource.com/setup_13.x | bash - && \
+	curl -sSfL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee -a /etc/apt/sources.list.d/yarn.list && \
+	apt-get update -y -qq && apt-get --no-install-recommends -y -qq install \
+					 docker-ce \
+					 google-cloud-sdk \
+					 nodejs \
+					 postgresql-client-10 \
+					 yarn && \
+	# Add deps to enable pyenv-driven on-demand python installs on KDK \
+	apt-get --no-install-recommends -y -qq install \
+		make build-essential \
+		libssl-dev \
+		zlib1g-dev \
+		libbz2-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		wget \
+		curl \
+		llvm \
+		libncurses5-dev \
+		libncursesw5-dev \
+		xz-utils \
+		tk-dev \
+		libffi-dev \
+		liblzma-dev \
+		python3-openssl && \
+	apt-get -y -qq clean && apt-get -y -qq autoremove && rm -rf /var/lib/apt/lists/*
 }
 
 function layer_install_python_based_utils_and_libs() {
     echo "#### ${FUNCNAME[0]}"
     curl -sSfL https://bootstrap.pypa.io/get-pip.py | python3 && \
-    pip3 install -qq --no-cache-dir -U setuptools && \
-    pip3 install -qq \
-         --no-cache-dir \
-         'ansible==2.9.2' \
-         'awscli==1.16.302' \
-         'boto3==1.10.38' \
-         'boto==2.49.0' \
-         'click==7.0' \
-         'docker-compose==1.25.0' \
-         'ipython==7.10.1' \
-         'ipdb==0.12.3' \
-         'Jinja2==2.10.3' \
-         'jinja2-cli[yaml]==0.7.0' \
-         'jsonschema==3.2.0' \
-         'openshift==0.10.0' \
-         'peru==1.2.0' \
-         'pipenv==2018.11.26' \
-         'pytest==5.3.1' \
-         'python-neutronclient==6.14.0' \
-         'python-octaviaclient==1.11.0' \
-         'python-openstackclient==3.19.0' \
-         'pyvmomi==6.7.3' \
-         'pyyaml==5.2' \
-         'requests==2.22.0' \
-         'sh==1.12.14' \
-         'sshuttle==0.78.5' \
-         'structlog==19.2.0' \
-         'urllib3==1.25.7' \
-         'virtualenv==16.7.8' \
-         'yamllint==1.19.0' \
-         'yapf==0.29.0' \
-         'yq==2.9.2' && \
-    rm -rf /root/.cache/pip
+	pip3 install --no-cache-dir -U setuptools && \
+	pip3 install \
+	     --no-cache-dir \
+	     'ansible==2.9.5' \
+	     'awscli==1.18.3' \
+	     'boto3==1.12.3' \
+	     'boto==2.49.0' \
+	     'click==7.0' \
+	     'docker-compose==1.25.4' \
+	     'ipython==7.12.0' \
+	     'ipdb' \
+	     'Jinja2' \
+	     'jinja2-cli[yaml]' \
+	     'jsonschema==3.2.0' \
+	     'openshift==0.10.2' \
+	     'peru==1.2.0' \
+	     'pipenv==2018.11.26' \
+	     'pytest==5.3.5' \
+	     'python-neutronclient==7.0.0' \
+	     'python-octaviaclient==2.0.0' \
+	     'python-openstackclient==4.0.0' \
+	     'pyvmomi==6.7.3' \
+	     'requests==2.23.0' \
+	     'sh==1.12.14' \
+	     'sshuttle==0.78.5' \
+	     'structlog==20.1.0' \
+	     'urllib3==1.25.8' \
+	     'virtualenv==20.0.4' \
+	     'yamllint==1.20.0' \
+	     'yapf' \
+	     'yq' && \
+	rm -rf /root/.cache/pip
 }
 
 function layer_install_apps_not_provided_by_os_packages() {
     echo "#### ${FUNCNAME[0]}"
     echo "Install apps (with pinned version) that are not provided by the OS packages." && \
-    echo "Install amtool." && \
-        export ORG="prometheus" && export REPO="alertmanager" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="amtool" && \
-        curl -sSfL https://github.com/"${ORG}/${REPO}"/releases/download/v"${VERSION}"/"${REPO}"-"${VERSION}".linux-amd64.tar.gz | tar xz && \
-        mv "${REPO}"*/"${ARTIFACT}" /usr/local/bin/"${ARTIFACT}" && rm -rf "${REPO}"* && \
-    echo "Install consul cli." && \
-        export ORG="hashicorp" && export REPO="consul" && export VERSION="1.6.2" && export ARTIFACT="${REPO}" && \
-        curl -sSfLo "${ARTIFACT}".zip https://releases."${ORG}".com/"${ARTIFACT}"/"${VERSION}"/"${ARTIFACT}"_"${VERSION}"_linux_amd64.zip && \
-        unzip -qq "${ARTIFACT}".zip && chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin && \
-        rm -rf "${ARTIFACT}"* && \
-    echo "Install dep." && \
-        export ORG="golang" && export REPO="dep" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}"  && \
-        curl -sSfLo "${ARTIFACT}" https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"-linux-amd64 && \
-        chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin && \
-    echo "Install direnv." && \
-        export ORG="direnv" && export REPO="direnv" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
-        curl -sSfLo "${ARTIFACT}" https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${REPO}".linux-amd64 && \
-        chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin && \
-    echo "Install drone-cli." && \
-        export ORG="drone" && export REPO="drone-cli" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${ORG}" && \
-        curl -sSfL https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"_linux_amd64.tar.gz | tar xz && \
-        chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin/"${ARTIFACT}"-"${VERSION}" && \
-        ln -sf /usr/local/bin/"${ARTIFACT}"-"${VERSION}" /usr/local/bin/"${ARTIFACT}" && \
-    echo "Install easy-rsa." && \
-        export ORG="OpenVPN" && export REPO="easy-rsa" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="EasyRSA" && \
-        curl -sSfL https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"-unix-v"${VERSION}".tgz | tar xz && \
-        chmod a+x "${ARTIFACT}"-v"${VERSION}"/$(echo "${ARTIFACT}" | tr '[:upper:]' '[:lower:]') && mv "${ARTIFACT}"-v"${VERSION}" /usr/local/share/"${ARTIFACT}"-"${VERSION}" && \
-        ln -s /usr/local/share/"${ARTIFACT}"-"${VERSION}"/$(echo "${ARTIFACT}" | tr '[:upper:]' '[:lower:]') /usr/local/bin/ && \
-    echo "Install etcdctl." && \
-        export ORG="etcd-io" && export REPO="etcd" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="etcdctl" && \
-        curl -sSfL https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${REPO}"-v"${VERSION}"-linux-amd64.tar.gz | tar xz && \
-        mv "${REPO}"*/${ARTIFACT} /usr/local/bin/${ARTIFACT} && rm -rf "${REPO}"* && \
-    echo "Install fluxctl." && \
-        export ORG="fluxcd" && export REPO="flux" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="fluxctl" && \
-        curl -sSfLo /usr/local/bin/"${ARTIFACT}" https://github.com/"${ORG}"/"${REPO}"/releases/download/"${VERSION}"/"${ARTIFACT}"_linux_amd64 && \
-        chmod a+x /usr/local/bin/"${ARTIFACT}" && \
-    echo "Install go-task." && \
-        export ORG="go-task" && export REPO="task" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
-        curl -sSfL https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"_linux_amd64.tar.gz | tar -C /usr/local/bin -xz "${ARTIFACT}" && chmod a+x /usr/local/bin/"${ARTIFACT}" && \
-    echo "Install gomplate." && \
-        export ORG="hairyhenderson" && export REPO="gomplate" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
-        curl -sSfLo "${ARTIFACT}" https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"_linux-amd64 && \
-        chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin && \
-    echo "Install golang." && \
-        export ORG="golang" && export REPO="go" && export VERSION="1.13.5" && export ARTIFACT="${REPO}" && \
-        curl -sSfL https://dl.google.com/"${REPO}"/"${ARTIFACT}""${VERSION}".linux-amd64.tar.gz | tar -C /usr/local -xz && \
-        mkdir -p /"${ARTIFACT}" && chmod a+rw /"${ARTIFACT}" && \
-    echo "Install goreleaser." && \
-        export ORG="goreleaser" && export REPO="goreleaser" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
-        curl -sSfLO https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"_Linux_x86_64.tar.gz && \
-        tar -C /usr/local/bin -xzf "${ARTIFACT}"*.tar.gz "${ARTIFACT}" && rm "${ARTIFACT}"*.tar.gz && \
-    echo "Install gradle." && \
-        export VERSION="6.0.1" && ARTIFACT="gradle" && \
-        curl -sSfLo "${ARTIFACT}".zip https://services."${ARTIFACT}".org/distributions/"${ARTIFACT}"-"${VERSION}"-bin.zip && \
-        unzip -d /usr/local/share -qq "${ARTIFACT}".zip && \
-        ln -sf /usr/local/share/"${ARTIFACT}"-"${VERSION}"/bin/gradle /usr/local/bin/"${ARTIFACT}" && \
-        rm -rf "${ARTIFACT}"* && \
-    echo "Install grpcurl." && \
-        export ORG="fullstorydev" && export REPO="grpcurl" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
-        curl -sSfL https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"_"${VERSION}"_linux_x86_64.tar.gz | tar -C /usr/local/bin -xz "${ARTIFACT}" && chmod a+x /usr/local/bin/"${ARTIFACT}" && \
-    echo "Install helm." && \
-        export ORG="helm" && export REPO="helm" && export ARTIFACT="${REPO}" && \
-        export VERSION="3.0.1" && curl -sSfL https://get.helm.sh/"${ARTIFACT}"-v"${VERSION}"-linux-amd64.tar.gz | tar xz && \
-            chmod a+x linux-amd64/"${ARTIFACT}" && mv linux-amd64/"${ARTIFACT}" /usr/local/bin/"${ARTIFACT}"-"${VERSION}" && rm -fr linux-amd64 &&
-            ln -sf /usr/local/bin/"${ARTIFACT}"-"${VERSION}" /usr/local/bin/"${ARTIFACT}"3 && \
-            ln -sf /usr/local/bin/"${ARTIFACT}"-"${VERSION}" /usr/local/bin/"${ARTIFACT}" && \
-        export VERSION="2.16.1" && curl -sSfL https://get.helm.sh/"${ARTIFACT}"-v"${VERSION}"-linux-amd64.tar.gz | tar xz && \
-            chmod a+x linux-amd64/"${ARTIFACT}" && mv linux-amd64/"${ARTIFACT}" /usr/local/bin/"${ARTIFACT}"-"${VERSION}" && rm -fr linux-amd64 &&
-            ln -sf /usr/local/bin/"${ARTIFACT}"-"${VERSION}" /usr/local/bin/"${ARTIFACT}"2 && \
-    echo "Install helmfile" && \
-        export ORG="roboll" && export REPO="helmfile" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
-        curl -sSfLo "${ARTIFACT}" https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"_linux_amd64 && \
-        chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin && \
-    echo "Install hugo." && \
-        export ORG="gohugoio" && export REPO="hugo" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
-        curl -sSfL https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"_"${VERSION}"_Linux-64bit.tar.gz | tar xz && \
-        chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin/"${ARTIFACT}" && \
-    echo "Install jq." && \
-        export ORG="stedolan" && export REPO="jq" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
-        curl -sSfLo "${ARTIFACT}" https://github.com/"${ORG}"/"${REPO}"/releases/download/"${VERSION}"/"${ARTIFACT}"-linux64 && \
-        chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin/ && \
-    echo "Install jsonnet." && \
-        export ORG="google" && export REPO="jsonnet" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="jsonnet" && \
-        curl -sSfL https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"-bin-v"${VERSION}"-linux.tar.gz | tar -C /usr/local/bin -xz && \
-    echo "Install kops." && \
-        export ORG="kubernetes" && export REPO="kops" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
-        curl -sSfLo /usr/local/bin/"${ARTIFACT}"-"${VERSION}" https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"-linux-amd64 && \
-        chmod a+x /usr/local/bin/"${ARTIFACT}"-"${VERSION}" && \
-        ln -sf /usr/local/bin/"${ARTIFACT}"-"${VERSION}" /usr/local/bin/"${ARTIFACT}" && \
-    echo "Install kubectl." && \
-        export ORG="kubernetes" && export REPO="kubernetes" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="kubectl" && \
-        curl -sSfLo /usr/local/bin/"${ARTIFACT}"-"${VERSION}" https://storage.googleapis.com/kubernetes-release/release/v"${VERSION}"/bin/linux/amd64/"${ARTIFACT}" && \
-        chmod a+x /usr/local/bin/"${ARTIFACT}"-"${VERSION}" && \
-        ln -sf /usr/local/bin/"${ARTIFACT}"-"${VERSION}" /usr/local/bin/"${ARTIFACT}" && \
-    echo "Install kubetail." && \
-        export ORG="johanhaleby" && export REPO="kubetail" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
-        curl -sSfLo "${ARTIFACT}".zip https://github.com/"${ORG}"/"${REPO}"/archive/"${VERSION}".zip && \
-        unzip -qq "${ARTIFACT}".zip && chmod a+x "${ARTIFACT}"-"${VERSION}"/"${ARTIFACT}" && mv "${ARTIFACT}"-"${VERSION}"/"${ARTIFACT}" /usr/local/bin && \
-        rm -rf "${ARTIFACT}"* && \
-    echo "Install maven." && \
-        export VERSION="3.6.3"
-        curl -sSfL http://apache.mirrors.tds.net/maven/maven-3/"${VERSION}"/binaries/apache-maven-"${VERSION}"-bin.tar.gz | tar -C /usr/local/share -xz && \
-        ln -sf /usr/local/share/apache-maven-"${VERSION}"/bin/mvn /usr/local/bin/mvn && \
-    echo "Install mc." && \
-        export ORG="minio" && export REPO="minio" && export ARTIFACT="mc" && \
-        curl -sSfLo /usr/local/bin/"${ARTIFACT}" https://dl."${ORG}".io/client/"${ARTIFACT}"/release/linux-amd64/"${ARTIFACT}" && \
-        chmod a+x /usr/local/bin/"${ARTIFACT}" && \
-    echo "Install minikube." && \
-        export ORG="kubernetes" && export REPO="minikube" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
-        curl -sSfLo /usr/local/bin/"${ARTIFACT}"-"${VERSION}" https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"-linux-amd64  && \
-        chmod a+x /usr/local/bin/"${ARTIFACT}"-"${VERSION}" && \
-        ln -sf /usr/local/bin/"${ARTIFACT}"-"${VERSION}" /usr/local/bin/"${ARTIFACT}" && \
-    echo "Install neovim." && \
-        export ORG="neovim" && export REPO="neovim" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="nvim" && \
-        mkdir -p /usr/local/share/"${ARTIFACT}" && curl -sSfL https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"-linux64.tar.gz | tar -C /usr/local/share/"${ARTIFACT}"  --strip-components=1 -xz && \
-        ln -sf /usr/local/share/"${ARTIFACT}"/bin/"${ARTIFACT}" /usr/local/bin/"${ARTIFACT}" && \
-    echo "Install sops." && \
-        export ORG="mozilla" && export REPO="sops" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
-        curl -sSfLo /usr/local/bin/"${ARTIFACT}" https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"-v"${VERSION}".linux && \
-        chmod a+x /usr/local/bin/"${ARTIFACT}" && \
-    echo "Install terraform." && \
-        export ORG="hashicorp" && export REPO="terraform" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
-        curl -sSfLo "${ARTIFACT}".zip https://releases."${ORG}".com/"${REPO}"/"${VERSION}"/"${ARTIFACT}"_"${VERSION}"_linux_amd64.zip && \
-        unzip -qq "${ARTIFACT}".zip && chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin/"${ARTIFACT}"-"${VERSION}" && rm -f "${ARTIFACT}".zip && \
-        ln -sf /usr/local/bin/"${ARTIFACT}"-"${VERSION}" /usr/local/bin/"${ARTIFACT}" && \
-    echo "Install testssl." && \
-        export ORG="drwetter" && export REPO="testssl.sh" && export VERSION="2.9.5-8" && export ARTIFACT="testssl" && \
-        curl -sSfL https://github.com/"${ORG}"/"${REPO}"/archive/v"${VERSION}".tar.gz | tar xz && \
-        mv "${ARTIFACT}"* /usr/local/share/"${ARTIFACT}" && ln -sf /usr/local/share/"${ARTIFACT}"/"${REPO}" /usr/local/bin/"${ARTIFACT}" && chmod a+x /usr/local/bin/"${ARTIFACT}" && \
-    echo "Install vault cli." && \
-        export ORG="hashicorp" && export REPO="vault" && export VERSION="1.3.0" && export ARTIFACT="${REPO}" && \
-        curl -sSfLo "${ARTIFACT}".zip https://releases."${ORG}".com/"${ARTIFACT}"/"${VERSION}"/"${ARTIFACT}"_"${VERSION}"_linux_amd64.zip && \
-        unzip -qq "${ARTIFACT}".zip && chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin && \
-        rm -rf "${ARTIFACT}"* && \
-    echo "Install yadm." && \
-        export ORG="thelocehiliosan" && export REPO="yadm" && export VERSION="2.2.0" && export ARTIFACT="${REPO}" && \
-        curl -sSfLo /usr/local/bin/"${ARTIFACT}" https://github.com/"${ORG}"/"${ARTIFACT}"/raw/"${VERSION}"/"${ARTIFACT}" && chmod a+x /usr/local/bin/"${ARTIFACT}"
+	echo "Install amtool." && \
+	export ORG="prometheus" && export REPO="alertmanager" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="amtool" && \
+	curl -sSfL https://github.com/"${ORG}/${REPO}"/releases/download/v"${VERSION}"/"${REPO}"-"${VERSION}".linux-amd64.tar.gz | tar xz && \
+	mv "${REPO}"*/"${ARTIFACT}" /usr/local/bin/"${ARTIFACT}" && rm -rf "${REPO}"* && \
+	echo "Install consul cli." && \
+	export ORG="hashicorp" && export REPO="consul" && export VERSION="1.6.2" && export ARTIFACT="${REPO}" && \
+	curl -sSfLo "${ARTIFACT}".zip https://releases."${ORG}".com/"${ARTIFACT}"/"${VERSION}"/"${ARTIFACT}"_"${VERSION}"_linux_amd64.zip && \
+	unzip -qq "${ARTIFACT}".zip && chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin && \
+	rm -rf "${ARTIFACT}"* && \
+	echo "Install dep." && \
+	export ORG="golang" && export REPO="dep" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}"  && \
+	curl -sSfLo "${ARTIFACT}" https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"-linux-amd64 && \
+	chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin && \
+	echo "Install direnv." && \
+	export ORG="direnv" && export REPO="direnv" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
+	curl -sSfLo "${ARTIFACT}" https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${REPO}".linux-amd64 && \
+	chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin && \
+	echo "Install drone-cli." && \
+	export ORG="drone" && export REPO="drone-cli" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${ORG}" && \
+	curl -sSfL https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"_linux_amd64.tar.gz | tar xz && \
+	chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin/"${ARTIFACT}"-"${VERSION}" && \
+	ln -sf /usr/local/bin/"${ARTIFACT}"-"${VERSION}" /usr/local/bin/"${ARTIFACT}" && \
+	echo "Install easy-rsa." && \
+	export ORG="OpenVPN" && export REPO="easy-rsa" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="EasyRSA" && \
+	curl -sSfL https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"-unix-v"${VERSION}".tgz | tar xz && \
+	chmod a+x "${ARTIFACT}"-v"${VERSION}"/$(echo "${ARTIFACT}" | tr '[:upper:]' '[:lower:]') && mv "${ARTIFACT}"-v"${VERSION}" /usr/local/share/"${ARTIFACT}"-"${VERSION}" && \
+	ln -s /usr/local/share/"${ARTIFACT}"-"${VERSION}"/$(echo "${ARTIFACT}" | tr '[:upper:]' '[:lower:]') /usr/local/bin/ && \
+	echo "Install etcdctl." && \
+	export ORG="etcd-io" && export REPO="etcd" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="etcdctl" && \
+	curl -sSfL https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${REPO}"-v"${VERSION}"-linux-amd64.tar.gz | tar xz && \
+	mv "${REPO}"*/${ARTIFACT} /usr/local/bin/${ARTIFACT} && rm -rf "${REPO}"* && \
+	echo "Install fluxctl." && \
+	export ORG="fluxcd" && export REPO="flux" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="fluxctl" && \
+	curl -sSfLo /usr/local/bin/"${ARTIFACT}" https://github.com/"${ORG}"/"${REPO}"/releases/download/"${VERSION}"/"${ARTIFACT}"_linux_amd64 && \
+	chmod a+x /usr/local/bin/"${ARTIFACT}" && \
+	echo "Install go-task." && \
+	export ORG="go-task" && export REPO="task" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
+	curl -sSfL https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"_linux_amd64.tar.gz | tar -C /usr/local/bin -xz "${ARTIFACT}" && chmod a+x /usr/local/bin/"${ARTIFACT}" && \
+	echo "Install gomplate." && \
+	export ORG="hairyhenderson" && export REPO="gomplate" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
+	curl -sSfLo "${ARTIFACT}" https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"_linux-amd64 && \
+	chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin && \
+	echo "Install golang." && \
+	export ORG="golang" && export REPO="go" && export VERSION="1.13.5" && export ARTIFACT="${REPO}" && \
+	curl -sSfL https://dl.google.com/"${REPO}"/"${ARTIFACT}""${VERSION}".linux-amd64.tar.gz | tar -C /usr/local -xz && \
+	mkdir -p /"${ARTIFACT}" && chmod a+rw /"${ARTIFACT}" && \
+	echo "Install goreleaser." && \
+	export ORG="goreleaser" && export REPO="goreleaser" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
+	curl -sSfLO https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"_Linux_x86_64.tar.gz && \
+	tar -C /usr/local/bin -xzf "${ARTIFACT}"*.tar.gz "${ARTIFACT}" && rm "${ARTIFACT}"*.tar.gz && \
+	echo "Install gradle." && \
+	export VERSION="6.0.1" && ARTIFACT="gradle" && \
+	curl -sSfLo "${ARTIFACT}".zip https://services."${ARTIFACT}".org/distributions/"${ARTIFACT}"-"${VERSION}"-bin.zip && \
+	unzip -d /usr/local/share -qq "${ARTIFACT}".zip && \
+	ln -sf /usr/local/share/"${ARTIFACT}"-"${VERSION}"/bin/gradle /usr/local/bin/"${ARTIFACT}" && \
+	rm -rf "${ARTIFACT}"* && \
+	echo "Install grpcurl." && \
+	export ORG="fullstorydev" && export REPO="grpcurl" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
+	curl -sSfL https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"_"${VERSION}"_linux_x86_64.tar.gz | tar -C /usr/local/bin -xz "${ARTIFACT}" && chmod a+x /usr/local/bin/"${ARTIFACT}" && \
+	echo "Install helm." && \
+	export ORG="helm" && export REPO="helm" && export ARTIFACT="${REPO}" && \
+	export VERSION="3.0.1" && curl -sSfL https://get.helm.sh/"${ARTIFACT}"-v"${VERSION}"-linux-amd64.tar.gz | tar xz && \
+	chmod a+x linux-amd64/"${ARTIFACT}" && mv linux-amd64/"${ARTIFACT}" /usr/local/bin/"${ARTIFACT}"-"${VERSION}" && rm -fr linux-amd64 &&
+	ln -sf /usr/local/bin/"${ARTIFACT}"-"${VERSION}" /usr/local/bin/"${ARTIFACT}"3 && \
+	    ln -sf /usr/local/bin/"${ARTIFACT}"-"${VERSION}" /usr/local/bin/"${ARTIFACT}" && \
+	    export VERSION="2.16.1" && curl -sSfL https://get.helm.sh/"${ARTIFACT}"-v"${VERSION}"-linux-amd64.tar.gz | tar xz && \
+	    chmod a+x linux-amd64/"${ARTIFACT}" && mv linux-amd64/"${ARTIFACT}" /usr/local/bin/"${ARTIFACT}"-"${VERSION}" && rm -fr linux-amd64 &&
+	    ln -sf /usr/local/bin/"${ARTIFACT}"-"${VERSION}" /usr/local/bin/"${ARTIFACT}"2 && \
+		echo "Install helmfile" && \
+		export ORG="roboll" && export REPO="helmfile" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
+		curl -sSfLo "${ARTIFACT}" https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"_linux_amd64 && \
+		chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin && \
+		echo "Install hugo." && \
+		export ORG="gohugoio" && export REPO="hugo" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
+		curl -sSfL https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"_"${VERSION}"_Linux-64bit.tar.gz | tar xz && \
+		chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin/"${ARTIFACT}" && \
+		echo "Install jq." && \
+		export ORG="stedolan" && export REPO="jq" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
+		curl -sSfLo "${ARTIFACT}" https://github.com/"${ORG}"/"${REPO}"/releases/download/"${VERSION}"/"${ARTIFACT}"-linux64 && \
+		chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin/ && \
+		echo "Install jsonnet." && \
+		export ORG="google" && export REPO="jsonnet" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="jsonnet" && \
+		curl -sSfL https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"-bin-v"${VERSION}"-linux.tar.gz | tar -C /usr/local/bin -xz && \
+		echo "Install kops." && \
+		export ORG="kubernetes" && export REPO="kops" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
+		curl -sSfLo /usr/local/bin/"${ARTIFACT}"-"${VERSION}" https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"-linux-amd64 && \
+		chmod a+x /usr/local/bin/"${ARTIFACT}"-"${VERSION}" && \
+		ln -sf /usr/local/bin/"${ARTIFACT}"-"${VERSION}" /usr/local/bin/"${ARTIFACT}" && \
+		echo "Install kubectl." && \
+		export ORG="kubernetes" && export REPO="kubernetes" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="kubectl" && \
+		curl -sSfLo /usr/local/bin/"${ARTIFACT}"-"${VERSION}" https://storage.googleapis.com/kubernetes-release/release/v"${VERSION}"/bin/linux/amd64/"${ARTIFACT}" && \
+		chmod a+x /usr/local/bin/"${ARTIFACT}"-"${VERSION}" && \
+		ln -sf /usr/local/bin/"${ARTIFACT}"-"${VERSION}" /usr/local/bin/"${ARTIFACT}" && \
+		echo "Install kubetail." && \
+		export ORG="johanhaleby" && export REPO="kubetail" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
+		curl -sSfLo "${ARTIFACT}".zip https://github.com/"${ORG}"/"${REPO}"/archive/"${VERSION}".zip && \
+		unzip -qq "${ARTIFACT}".zip && chmod a+x "${ARTIFACT}"-"${VERSION}"/"${ARTIFACT}" && mv "${ARTIFACT}"-"${VERSION}"/"${ARTIFACT}" /usr/local/bin && \
+		rm -rf "${ARTIFACT}"* && \
+		echo "Install maven." && \
+		export VERSION="3.6.3"
+    curl -sSfL http://apache.mirrors.tds.net/maven/maven-3/"${VERSION}"/binaries/apache-maven-"${VERSION}"-bin.tar.gz | tar -C /usr/local/share -xz && \
+	ln -sf /usr/local/share/apache-maven-"${VERSION}"/bin/mvn /usr/local/bin/mvn && \
+	echo "Install mc." && \
+	export ORG="minio" && export REPO="minio" && export ARTIFACT="mc" && \
+	curl -sSfLo /usr/local/bin/"${ARTIFACT}" https://dl."${ORG}".io/client/"${ARTIFACT}"/release/linux-amd64/"${ARTIFACT}" && \
+	chmod a+x /usr/local/bin/"${ARTIFACT}" && \
+	echo "Install minikube." && \
+	export ORG="kubernetes" && export REPO="minikube" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
+	curl -sSfLo /usr/local/bin/"${ARTIFACT}"-"${VERSION}" https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"-linux-amd64  && \
+	chmod a+x /usr/local/bin/"${ARTIFACT}"-"${VERSION}" && \
+	ln -sf /usr/local/bin/"${ARTIFACT}"-"${VERSION}" /usr/local/bin/"${ARTIFACT}" && \
+	echo "Install neovim." && \
+	export ORG="neovim" && export REPO="neovim" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="nvim" && \
+	mkdir -p /usr/local/share/"${ARTIFACT}" && curl -sSfL https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"-linux64.tar.gz | tar -C /usr/local/share/"${ARTIFACT}"  --strip-components=1 -xz && \
+	ln -sf /usr/local/share/"${ARTIFACT}"/bin/"${ARTIFACT}" /usr/local/bin/"${ARTIFACT}" && \
+	echo "Install sops." && \
+	export ORG="mozilla" && export REPO="sops" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
+	curl -sSfLo /usr/local/bin/"${ARTIFACT}" https://github.com/"${ORG}"/"${REPO}"/releases/download/v"${VERSION}"/"${ARTIFACT}"-v"${VERSION}".linux && \
+	chmod a+x /usr/local/bin/"${ARTIFACT}" && \
+	echo "Install terraform." && \
+	export ORG="hashicorp" && export REPO="terraform" && export VERSION=$(get_latest_github_release_version "${ORG}" "${REPO}") && export ARTIFACT="${REPO}" && \
+	curl -sSfLo "${ARTIFACT}".zip https://releases."${ORG}".com/"${REPO}"/"${VERSION}"/"${ARTIFACT}"_"${VERSION}"_linux_amd64.zip && \
+	unzip -qq "${ARTIFACT}".zip && chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin/"${ARTIFACT}"-"${VERSION}" && rm -f "${ARTIFACT}".zip && \
+	ln -sf /usr/local/bin/"${ARTIFACT}"-"${VERSION}" /usr/local/bin/"${ARTIFACT}" && \
+	echo "Install testssl." && \
+	export ORG="drwetter" && export REPO="testssl.sh" && export VERSION="2.9.5-8" && export ARTIFACT="testssl" && \
+	curl -sSfL https://github.com/"${ORG}"/"${REPO}"/archive/v"${VERSION}".tar.gz | tar xz && \
+	mv "${ARTIFACT}"* /usr/local/share/"${ARTIFACT}" && ln -sf /usr/local/share/"${ARTIFACT}"/"${REPO}" /usr/local/bin/"${ARTIFACT}" && chmod a+x /usr/local/bin/"${ARTIFACT}" && \
+	echo "Install vault cli." && \
+	export ORG="hashicorp" && export REPO="vault" && export VERSION="1.3.0" && export ARTIFACT="${REPO}" && \
+	curl -sSfLo "${ARTIFACT}".zip https://releases."${ORG}".com/"${ARTIFACT}"/"${VERSION}"/"${ARTIFACT}"_"${VERSION}"_linux_amd64.zip && \
+	unzip -qq "${ARTIFACT}".zip && chmod a+x "${ARTIFACT}" && mv "${ARTIFACT}" /usr/local/bin && \
+	rm -rf "${ARTIFACT}"* && \
+	echo "Install yadm." && \
+	export ORG="thelocehiliosan" && export REPO="yadm" && export VERSION="2.2.0" && export ARTIFACT="${REPO}" && \
+	curl -sSfLo /usr/local/bin/"${ARTIFACT}" https://github.com/"${ORG}"/"${ARTIFACT}"/raw/"${VERSION}"/"${ARTIFACT}" && chmod a+x /usr/local/bin/"${ARTIFACT}"
 }
 
 function layer_go_get_installs() {
     echo "#### ${FUNCNAME[0]}"
     export GOPATH=/go && \
-    echo "go get installs" && \
-      apt-get -y -qq update && apt-get --no-install-recommends -y -qq install git && \
-      apt-get -y -qq clean && apt-get -y -qq autoremove && rm -rf /var/lib/apt/lists/*
+	echo "go get installs" && \
+	apt-get -y -qq update && apt-get --no-install-recommends -y -qq install git && \
+	apt-get -y -qq clean && apt-get -y -qq autoremove && rm -rf /var/lib/apt/lists/*
     /usr/local/go/bin/go get github.com/cloudflare/cfssl/cmd/cfssl
     /usr/local/go/bin/go get github.com/cloudflare/cfssl/cmd/cfssljson
     /usr/local/go/bin/go get github.com/spf13/cobra/cobra
@@ -401,9 +411,9 @@ function layer_go_get_installs() {
     /usr/local/go/bin/go get github.com/vmware/govmomi/govc
     /usr/local/go/bin/go get github.com/github/hub
     git clone https://github.com/cisco-sso/mh.git /tmp/mh && cd /tmp/mh && \
-        /usr/local/go/bin/go mod init github.com/cisco-sso/mh && \
-        /usr/local/go/bin/go build -o /go/bin/mh && \
-        ln -sf /go/bin/mh /go/bin/multihelm
+	/usr/local/go/bin/go mod init github.com/cisco-sso/mh && \
+	/usr/local/go/bin/go build -o /go/bin/mh && \
+	ln -sf /go/bin/mh /go/bin/multihelm
     GO111MODULE=on /usr/local/go/bin/go get github.com/mikefarah/yq/v2
     rm -rf /root/.cache/go-build
     rm -rf /go/src
@@ -412,102 +422,102 @@ function layer_go_get_installs() {
 function layer_build_apps_not_provided_by_os_packages() {
     echo "#### ${FUNCNAME[0]}"
     apt-get -y -qq update && apt-get --no-install-recommends -y -qq install \
-        autoconf \
-        build-essential \
-        gcc \
-        libgnutls28-dev \
-        libncurses5-dev \
-        libz-dev \
-        texinfo \
-        yodl && \
-    apt-get -y -qq clean && apt-get -y -qq autoremove && rm -rf /var/lib/apt/lists/*
+				     autoconf \
+				     build-essential \
+				     gcc \
+				     libgnutls28-dev \
+				     libncurses5-dev \
+				     libz-dev \
+				     texinfo \
+				     yodl && \
+	apt-get -y -qq clean && apt-get -y -qq autoremove && rm -rf /var/lib/apt/lists/*
 
     echo "Install git (needs to build first as a dependency)." && \
-        export ORG="git" && export REPO="git" && export VERSION="2.24.1" && export ARTIFACT="${REPO}" && \
-        curl -sSfL https://github.com/"${ORG}"/"${REPO}"/archive/v"${VERSION}".tar.gz | tar xz && cd git-* && \
-        make configure && ./configure --prefix=/usr/local && make && make install && cd .. && rm -fr git-*
+	export ORG="git" && export REPO="git" && export VERSION="2.24.1" && export ARTIFACT="${REPO}" && \
+	curl -sSfL https://github.com/"${ORG}"/"${REPO}"/archive/v"${VERSION}".tar.gz | tar xz && cd git-* && \
+	make configure && ./configure --prefix=/usr/local && make && make install && cd .. && rm -fr git-*
 
     echo "Install bats" && \
-    curl -sSfL https://github.com/sstephenson/bats/archive/v0.4.0.tar.gz | tar xz && cd bats-* && \
-    ./install.sh /usr/local && cd .. && rm -fr bats-*
+	curl -sSfL https://github.com/sstephenson/bats/archive/v0.4.0.tar.gz | tar xz && cd bats-* && \
+	./install.sh /usr/local && cd .. && rm -fr bats-*
 
     echo "Install emacs." && \
-        curl -sSfL http://mirrors.ibiblio.org/gnu/ftp/gnu/emacs/emacs-26.3.tar.gz | tar xz && cd emacs-* && \
-        CANNOT_DUMP=yes ./configure \
-            --prefix=/usr/local \
-            --disable-build-details \
-            --without-all \
-            --without-x \
-            --without-x-toolkit \
-            --without-sound \
-            --with-xml2 \
-            --with-zlib \
-            --with-modules \
-            --with-file-notification \
-            --with-gnutls \
-            --with-compress-install && \
-        make && make install && cd .. && rm -fr emacs-*
+	curl -sSfL http://mirrors.ibiblio.org/gnu/ftp/gnu/emacs/emacs-26.3.tar.gz | tar xz && cd emacs-* && \
+	CANNOT_DUMP=yes ./configure \
+		   --prefix=/usr/local \
+		   --disable-build-details \
+		   --without-all \
+		   --without-x \
+		   --without-x-toolkit \
+		   --without-sound \
+		   --with-xml2 \
+		   --with-zlib \
+		   --with-modules \
+		   --with-file-notification \
+		   --with-gnutls \
+		   --with-compress-install && \
+	make && make install && cd .. && rm -fr emacs-*
 
     echo "Install pyenv with dependencies." && \
-        curl -sSfLo pyenv-installer https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer && \
-        chmod a+x pyenv-installer && mv pyenv-installer /usr/local/bin && \
-        PYENV_ROOT=/usr/local/pyenv pyenv-installer && chmod -R a+rwx /usr/local/pyenv
+	curl -sSfLo pyenv-installer https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer && \
+	chmod a+x pyenv-installer && mv pyenv-installer /usr/local/bin && \
+	PYENV_ROOT=/usr/local/pyenv pyenv-installer && chmod -R a+rwx /usr/local/pyenv
 
     echo "Install vim." && \
-        export ORG="vim" && export REPO="vim" && export VERSION="8.2.0" && export ARTIFACT="${REPO}" && \
-        curl -sSfL https://github.com/"${ORG}"/"${REPO}"/archive/v"${VERSION}".tar.gz | tar xz && cd "${ARTIFACT}"-* && \
-        ./configure \
-            --with-features=huge \
-            --enable-multibyte \
-            --enable-rubyinterp=yes \
-            --enable-pythoninterp=yes \
-            --enable-python3interp=yes \
-            --enable-perlinterp=yes \
-            --enable-luainterp=yes \
-            --enable-cscope \
-            --prefix=/usr/local && \
-        make VIMRUNTIMEDIR=/usr/local/share/vim/vim82 && make install && cd .. && rm -fr vim-* && \
-        ln -sf /usr/local/bin/vim /usr/local/bin/vi
+	export ORG="vim" && export REPO="vim" && export VERSION="8.2.0" && export ARTIFACT="${REPO}" && \
+	curl -sSfL https://github.com/"${ORG}"/"${REPO}"/archive/v"${VERSION}".tar.gz | tar xz && cd "${ARTIFACT}"-* && \
+	./configure \
+	    --with-features=huge \
+	    --enable-multibyte \
+	    --enable-rubyinterp=yes \
+	    --enable-pythoninterp=yes \
+	    --enable-python3interp=yes \
+	    --enable-perlinterp=yes \
+	    --enable-luainterp=yes \
+	    --enable-cscope \
+	    --prefix=/usr/local && \
+	make VIMRUNTIMEDIR=/usr/local/share/vim/vim82 && make install && cd .. && rm -fr vim-* && \
+	ln -sf /usr/local/bin/vim /usr/local/bin/vi
 
     echo "Install tmux." && \
-        curl -sSfL https://github.com/libevent/libevent/releases/download/release-2.1.11-stable/libevent-2.1.11-stable.tar.gz | tar xz && cd libevent-* && \
-        ./configure && make && make install && cd .. && rm -fr libevent-* && \
-        curl -sSfL https://github.com/tmux/tmux/releases/download/3.0a/tmux-3.0a.tar.gz | tar xz && cd tmux-* && \
-        ./configure --prefix=/usr/local && make && make install && cd .. && rm -fr tmux-*
+	curl -sSfL https://github.com/libevent/libevent/releases/download/release-2.1.11-stable/libevent-2.1.11-stable.tar.gz | tar xz && cd libevent-* && \
+	./configure && make && make install && cd .. && rm -fr libevent-* && \
+	curl -sSfL https://github.com/tmux/tmux/releases/download/3.0a/tmux-3.0a.tar.gz | tar xz && cd tmux-* && \
+	./configure --prefix=/usr/local && make && make install && cd .. && rm -fr tmux-*
 
     echo "Install zsh." && \
-        export ORG="zsh-users" && export REPO="zsh" && export VERSION="5.7.1" && export ARTIFACT="${REPO}" && \
-        curl -sSfL https://github.com/"${ORG}"/"${REPO}"/archive/"${ARTIFACT}"-"${VERSION}".tar.gz | tar xz && cd "${ARTIFACT}"-* && \
-        ./Util/preconfig && \
-        ./configure \
-            --prefix=/usr/local \
-            --mandir=/usr/local/share/man \
-            --bindir=/usr/local/bin \
-            --infodir=/usr/local/share/info \
-            --enable-maildir-support \
-            --enable-etcdir=/usr/local/etc/zsh \
-            --enable-function-subdirs \
-            --enable-site-fndir=/usr/local/share/zsh/site-functions \
-            --enable-fndir=/usr/local/share/zsh/functions \
-            --with-tcsetpgrp \
-            --with-term-lib="ncursesw" \
-            --enable-cap \
-            --enable-pcre \
-            --enable-readnullcmd=pager \
-            --enable-custom-patchlevel=Debian \
-            LDFLAGS="-Wl,--as-needed -g" && \
-        make && make install && echo "/usr/local/bin/zsh" >> /etc/shells && cd .. && rm -fr zsh-*
+	export ORG="zsh-users" && export REPO="zsh" && export VERSION="5.7.1" && export ARTIFACT="${REPO}" && \
+	curl -sSfL https://github.com/"${ORG}"/"${REPO}"/archive/"${ARTIFACT}"-"${VERSION}".tar.gz | tar xz && cd "${ARTIFACT}"-* && \
+	./Util/preconfig && \
+	./configure \
+	    --prefix=/usr/local \
+	    --mandir=/usr/local/share/man \
+	    --bindir=/usr/local/bin \
+	    --infodir=/usr/local/share/info \
+	    --enable-maildir-support \
+	    --enable-etcdir=/usr/local/etc/zsh \
+	    --enable-function-subdirs \
+	    --enable-site-fndir=/usr/local/share/zsh/site-functions \
+	    --enable-fndir=/usr/local/share/zsh/functions \
+	    --with-tcsetpgrp \
+	    --with-term-lib="ncursesw" \
+	    --enable-cap \
+	    --enable-pcre \
+	    --enable-readnullcmd=pager \
+	    --enable-custom-patchlevel=Debian \
+	    LDFLAGS="-Wl,--as-needed -g" && \
+	make && make install && echo "/usr/local/bin/zsh" >> /etc/shells && cd .. && rm -fr zsh-*
 
     echo "Install redis-cli tools." && \
-        curl -sSfL http://download.redis.io/releases/redis-5.0.7.tar.gz | tar xz && cd redis-* && \
-        make && cp src/redis-cli src/redis-benchmark /usr/local/bin && cd .. && rm -fr redis-*
+	curl -sSfL http://download.redis.io/releases/redis-5.0.7.tar.gz | tar xz && cd redis-* && \
+	make && cp src/redis-cli src/redis-benchmark /usr/local/bin && cd .. && rm -fr redis-*
 }
 
 function exit_if_provisioned() {
     echo "#### ${FUNCNAME[0]}"
     if [ -f /var/lib/provisioned ]; then
-        echo "Already provisioned since exists: /var/lib/provisioned"
-        exit 0
+	echo "Already provisioned since exists: /var/lib/provisioned"
+	exit 0
     fi
 }
 

--- a/packer/Makefile
+++ b/packer/Makefile
@@ -7,10 +7,10 @@ deps_windows:
 	choco install -y make packer git
 
 build_virtualbox: validate  ## Build the virtualbox vagrant image
-	PACKER_LOG=1 packer build packer_virtualbox.json 2>&1 | tee build-virtualbox.log
+	PACKER_LOG=1 GITHUB_API_TOKEN=${GITHUB_API_TOKEN} packer build packer_virtualbox.json 2>&1 | tee build-virtualbox.log
 
 build_hyperv: validate  ## Build the hyperv vagrant images
-	PACKER_LOG=1 packer build packer_hyperv.json     2>&1 | tee build-hyperv.log
+	PACKER_LOG=1 GITHUB_API_TOKEN=${GITHUB_API_TOKEN} packer build packer_hyperv.json     2>&1 | tee build-hyperv.log
 
 add_box:  ## Add the box as kdk/test
 	vagrant box remove kdk/test 2>&1 > /dev/null || true
@@ -19,6 +19,7 @@ add_box:  ## Add the box as kdk/test
 validate:  ## Validate the packer json files
 	packer validate packer_virtualbox.json
 	packer validate packer_hyperv.json
+	@if [[ -z "${GITHUB_API_TOKEN}" ]]; then echo "ERROR: GITHUB_API_TOKEN env var must be set: export GITHUB_API_TOKEN=(token created from https://github.com/settings/tokens)"; exit 1; fi
 
 clean:  ## Clean up the build dirs
 	@rm -rf *.log output-vagrant *~

--- a/packer/README.md
+++ b/packer/README.md
@@ -11,6 +11,8 @@ Supported targets/hypervisors:
 ## Mac Virtualbox Build
 
 ```bash
+# Set a Github API Token so that API call throttling limits are increased
+export GITHUB_API_TOKEN=<token created from https://github.com/settings/tokens>
 
 # Enter the packer build directory
 cd kdk/packer
@@ -28,6 +30,9 @@ make clean build_virtualbox
 # Start Powershell as Administrator
 # Start a bash shell in git
 C:\Program Files\git\bin\bash.exe
+
+# Set a Github API Token so that API call throttling limits are increased
+export GITHUB_API_TOKEN=<token created from https://github.com/settings/tokens>
 
 # Enter the packer build directory
 cd kdk/packer
@@ -48,7 +53,7 @@ make add_box
 # Create a vagrant file
 mkdir -p vagrant-test
 cd vagrant-test
-vagrant init kdk/ubuntu-18.04-test
+vagrant init kdk/test
 
 # Start the box
 vagrant up

--- a/packer/packer_hyperv.json
+++ b/packer/packer_hyperv.json
@@ -1,4 +1,7 @@
 {
+  "variables": {
+    "GITHUB_API_TOKEN": "{{env `GITHUB_API_TOKEN`}}"
+  },
   "builders": [
     {
       "type": "vagrant",
@@ -16,9 +19,12 @@
     {
       "type": "shell",
       "script": "../files/provision.sh",
+      "environment_vars": [
+	"GITHUB_API_TOKEN={{user `GITHUB_API_TOKEN`}}"
+      ],
       "override": {
         "vagrant": {
-          "execute_command": "sudo {{.Path}} vagrant"
+          "execute_command": "sudo {{.Vars}} {{.Path}} vagrant"
         }
       }
     },

--- a/packer/packer_virtualbox.json
+++ b/packer/packer_virtualbox.json
@@ -1,4 +1,7 @@
 {
+  "variables": {
+    "GITHUB_API_TOKEN": "{{env `GITHUB_API_TOKEN`}}"
+  },
   "builders": [
     {
       "type": "vagrant",
@@ -15,9 +18,12 @@
     {
       "type": "shell",
       "script": "../files/provision.sh",
+      "environment_vars": [
+	"GITHUB_API_TOKEN={{user `GITHUB_API_TOKEN`}}"
+      ],
       "override": {
         "vagrant": {
-          "execute_command": "sudo {{.Path}} vagrant"
+          "execute_command": "sudo {{.Vars}} {{.Path}} vagrant"
         }
       }
     },


### PR DESCRIPTION
* Require that the user provide a GITHUB_API_TOKEN that is
  used upon calling the Github API to figure out latest releases.
* This fixes random CircleCI build failures, since non-auth'd
  requests are counted by egress IP address.
* This also fixes local build failures.
* User now required to set env var GITHUB_API_TOKEN