### PR TITLE
pre-install jb v0.3.0

### DIFF
--- a/files/provision.sh
+++ b/files/provision.sh
@@ -415,6 +415,7 @@ function layer_go_get_installs() {
 	/usr/local/go/bin/go build -o /go/bin/mh && \
 	ln -sf /go/bin/mh /go/bin/multihelm
     GO111MODULE=on /usr/local/go/bin/go get github.com/mikefarah/yq/v2
+    GO111MODULE=on /usr/local/go/bin/go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.3.0
     rm -rf /root/.cache/go-build
     rm -rf /go/src
 }


### PR DESCRIPTION
This version of jb will install jsonnet lib to go-like vendor directories which will help us a lot:

https://github.com/jsonnet-bundler/jsonnet-bundler/releases/tag/v0.3.0